### PR TITLE
add wp_body_open() to header.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -20,6 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 <body <?php body_class(); ?>>
 
 <?php
+
+if( function_exists( 'wp_body_open' ) ) {
+	wp_body_open();
+} else {
+	do_action( 'wp_body_open' );
+}
+
 if ( ! function_exists( 'elementor_theme_do_location' ) || ! elementor_theme_do_location( 'header' ) ) {
 	get_template_part( 'template-parts/header' );
 }


### PR DESCRIPTION
Adds the new (5.2.0) core function wp_body_open() responsible for firing the new action hook with the same name. Plugin authors can finally access the start of the body tag via a official hook.

see: https://developer.wordpress.org/reference/functions/wp_body_open/