### PR TITLE
Add a footer menu system

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,7 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_register_menus', [ true ], '2.0', 'hello_elementor_register_menus' );
 		if ( apply_filters( 'hello_elementor_register_menus', $hook_result ) ) {
 			register_nav_menus( array( 'menu-1' => __( 'Primary', 'hello-elementor' ) ) );
+			register_nav_menus( array( 'menu-2' => __( 'Secondary', 'hello-elementor' ) ) );
 		}
 
 		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_add_theme_support', [ true ], '2.0', 'hello_elementor_add_theme_support' );

--- a/template-parts/footer.php
+++ b/template-parts/footer.php
@@ -4,6 +4,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <footer id="site-footer" class="site-footer" role="contentinfo">
+	
+	<nav id="bottom-menu" role="navigation">
+		<?php wp_nav_menu( array( 'theme_location' => 'menu-2' ) ); ?>
+	</nav>
 
 	<?php // footer ?>
 


### PR DESCRIPTION
It's a nice idea to have a seperate assignable menu in the footer area, to manage things like Privacy Policy, Terms & Conditions, Copyright links etc. as distinct from the top menu. It also allows for a footer menu to be targeted in other PHP scripts / plugins.