### PR TITLE
Fixed conflicts with minifier cssnano and css animations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,10 @@ module.exports = function( grunt ) {
 						require( 'autoprefixer' )( {
 							browsers: 'last 3 versions'
 						} ),
-						require( 'cssnano' )()
+						require("cssnano")({
+							reduceIdents: false,
+						   	discardUnused: false
+						})
 					]
 				},
 				files: [ {


### PR DESCRIPTION
## Type of Pull Request
- [ ] New feature
- [x] Bug fix
- [ ] Refactor

## Description
There is a conflict when you try to add css animations in the theme.

cssnano in Gulp renames the animations and they broke. 

## Issue reference
I found that other developers had the same problem with the minifier, I found the solution to it and apply it to gulpfile.js. The solution is in this closed issue from cssnano github: https://github.com/cssnano/cssnano/issues/247