### PR TITLE
Remove caption centering by default

### DIFF
--- a/assets/scss/theme/_general.scss
+++ b/assets/scss/theme/_general.scss
@@ -65,7 +65,6 @@ to override any of the settings in this section, add your styling code in the cu
 
 .wp-caption-text {
 	margin: 0;
-	text-align: center;
 }
 
 //Text meant only for screen readers:


### PR DESCRIPTION
Removing center text for captions by default allows the Elementor Image Widget to control the alignment of the image and caption without needing to set an explicit alignment for the caption. Solves elementor/elementor#10003