### PR TITLE
Archive template: Sanitize content for allowed HTML tags in post title 

### DIFF
--- a/template-parts/archive.php
+++ b/template-parts/archive.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			?>
 			<article class="post">
 				<?php
-				printf( '<h2 class="%s"><a href="%s">%s</a></h2>', 'entry-title', esc_url( $post_link ), esc_html( get_the_title() ) );
+				printf( '<h2 class="%s"><a href="%s">%s</a></h2>', 'entry-title', esc_url( $post_link ), wp_kses_post( get_the_title() ) );
 				printf( '<a href="%s">%s</a>', esc_url( $post_link ), get_the_post_thumbnail( $post, 'large' ) );
 				the_excerpt();
 				?>


### PR DESCRIPTION
For better or worse, html tags are allowed in the WP post title field. If a user inputs html into the title field then it should be OK to allow the html to render (instead of displaying escaped html tags)

A screenshot before adding this tweak:
![before](https://user-images.githubusercontent.com/891156/79388505-77ec6300-7f3b-11ea-9d29-90e6bcd81c5a.png)

and after:
![after](https://user-images.githubusercontent.com/891156/79388535-7f137100-7f3b-11ea-8e4a-e29e90c3d2fb.png)


