### PR TITLE
Add theme support for Gutenberg wide/full images

### DIFF
--- a/assets/scss/theme/_general.scss
+++ b/assets/scss/theme/_general.scss
@@ -23,6 +23,22 @@ to override any of the settings in this section, add your styling code in the cu
 	margin-right: auto;
 }
 
+.alignwide {
+	margin-left: -80px;
+	margin-right: -80px;
+}
+
+.alignfull {
+	margin-left: calc(50% - 50vw);
+	margin-right: calc(50% - 50vw);
+	max-width: 100vw;
+	width: 100vw;
+
+	img  {
+		width: 100vw;
+	}
+}
+
 .pagination {
 	margin: 20px auto;
 }

--- a/functions.php
+++ b/functions.php
@@ -61,6 +61,11 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 			 * Editor Style.
 			 */
 			add_editor_style( 'editor-style.css' );
+			
+			/*
+			 * Gutenberg wide images.
+			 */
+			add_theme_support( 'align-wide' );
 
 			/*
 			 * WooCommerce.


### PR DESCRIPTION
Images 3 align options right/center/left. Gutenberg introduced 2 new alignment options (wide/full).

Themes must support them with `add_theme_support( 'align-wide' )` in `functions.php` file. They also need to add custom CSS.

This will add to the block editor the two new align options:

**Wide alignment:**

![wide-alignment](https://user-images.githubusercontent.com/576623/79980240-78d94380-84ab-11ea-9765-e9c052f7a6ee.jpg)

**Full alignment:**

![full-width](https://user-images.githubusercontent.com/576623/79980247-7b3b9d80-84ab-11ea-9efc-c78a2884fc01.jpg)

This PR added wide/full images support to Elementor Hello Theme.