### PR TITLE
Fixed font weirdness in editor-style.css

### DIFF
--- a/editor-style.css
+++ b/editor-style.css
@@ -15,21 +15,13 @@ img {
   border-style: none; }
 
 pre {
-  font-family: monospace, monospace;
-  font-size: 1em;
   white-space: pre-wrap; }
 
 code,
 kbd,
 pre,
 samp {
-  font-size: 1rem; }
-
-code,
-kbd,
-pre,
-samp {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: monospace;
   font-size: 1rem; }
 
 blockquote {

--- a/editor-style.min.css
+++ b/editor-style.min.css
@@ -1,1 +1,1 @@
-p{margin-bottom:.75rem}img{max-width:100%;height:auto;vertical-align:middle;border-style:none}pre{font-family:monospace,monospace;font-size:1em;white-space:pre-wrap}code,kbd,pre,samp{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif;font-size:1rem}blockquote{font-style:italic}
+p{margin-bottom:.75rem}img{max-width:100%;height:auto;vertical-align:middle;border-style:none}pre{white-space:pre-wrap}code,kbd,pre,samp{font-family:monospace;font-size:1rem}blockquote{font-style:italic}


### PR DESCRIPTION
There's some strangeness in the editor styles. There's redundant code, styles that override styles that were just set, and most importantly, a really terrible font choice for code-related elements. I've fixed these.