### PR TITLE
Post Password Form Submit (Enter) button alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -592,3 +592,14 @@ li {
   font-size: 100%;
   vertical-align: baseline;
   background: transparent; }
+
+/**
+ * Post Password Form Submit button alignment
+ */
+.post-password-form p {
+	width: 100%;
+	display: flex;
+	align-items: flex-end; }
+
+.post-password-form [type=submit] {
+	margin-left: 3px; }


### PR DESCRIPTION
When a post is password-protected, the Post Password Form **Submit** button isn't aligned properly (please check the attached before/after screenshots).

![before](https://user-images.githubusercontent.com/25090391/112749159-28c30500-8fc9-11eb-846e-259903cdd756.png)

![after](https://user-images.githubusercontent.com/25090391/112749158-282a6e80-8fc9-11eb-9ede-cf895c9b2ed8.png)

Here is a relevant WP.org topic:
https://wordpress.org/support/topic/customizing-password-protected-pages/