### PR TITLE
Removed "theme switching", "update transient" hook callbacks, replaced by Elementor Experiments flag [ED-4050]

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -84,9 +84,24 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 				add_theme_support( 'wc-product-gallery-slider' );
 			}
 		}
+
+		maybe_update_theme_version_in_db();
 	}
 }
 add_action( 'after_setup_theme', 'hello_elementor_setup' );
+
+if ( ! function_exists( 'maybe_update_theme_version_in_db' ) ) {
+	function maybe_update_theme_version_in_db() {
+		$theme_version_option_name = 'hello_theme_version';
+		// The theme version saved in the database.
+		$hello_theme_db_version = get_option( $theme_version_option_name );
+
+		// If the 'hello_theme_version' option does not exist in the DB, or the version needs to be updated, do the update.
+		if ( ! $hello_theme_db_version || version_compare( $hello_theme_db_version, HELLO_ELEMENTOR_VERSION, '<' ) ) {
+			update_option( $theme_version_option_name, HELLO_ELEMENTOR_VERSION, true );
+		}
+	}
+}
 
 if ( ! function_exists( 'hello_elementor_scripts_styles' ) ) {
 	/**

--- a/functions.php
+++ b/functions.php
@@ -22,6 +22,10 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 	 * @return void
 	 */
 	function hello_elementor_setup() {
+		if ( is_admin() ) {
+			hello_maybe_update_theme_version_in_db();
+		}
+
 		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_load_textdomain', [ true ], '2.0', 'hello_elementor_load_textdomain' );
 		if ( apply_filters( 'hello_elementor_load_textdomain', $hook_result ) ) {
 			load_theme_textdomain( 'hello-elementor', get_template_directory() . '/languages' );
@@ -84,8 +88,6 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 				add_theme_support( 'wc-product-gallery-slider' );
 			}
 		}
-
-		hello_maybe_update_theme_version_in_db();
 	}
 }
 add_action( 'after_setup_theme', 'hello_elementor_setup' );

--- a/functions.php
+++ b/functions.php
@@ -97,7 +97,7 @@ function hello_maybe_update_theme_version_in_db() {
 
 	// If the 'hello_theme_version' option does not exist in the DB, or the version needs to be updated, do the update.
 	if ( ! $hello_theme_db_version || version_compare( $hello_theme_db_version, HELLO_ELEMENTOR_VERSION, '<' ) ) {
-		update_option( $theme_version_option_name, HELLO_ELEMENTOR_VERSION, true );
+		update_option( $theme_version_option_name, HELLO_ELEMENTOR_VERSION );
 	}
 }
 

--- a/functions.php
+++ b/functions.php
@@ -85,21 +85,19 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 			}
 		}
 
-		maybe_update_theme_version_in_db();
+		hello_maybe_update_theme_version_in_db();
 	}
 }
 add_action( 'after_setup_theme', 'hello_elementor_setup' );
 
-if ( ! function_exists( 'maybe_update_theme_version_in_db' ) ) {
-	function maybe_update_theme_version_in_db() {
-		$theme_version_option_name = 'hello_theme_version';
-		// The theme version saved in the database.
-		$hello_theme_db_version = get_option( $theme_version_option_name );
+function hello_maybe_update_theme_version_in_db() {
+	$theme_version_option_name = 'hello_theme_version';
+	// The theme version saved in the database.
+	$hello_theme_db_version = get_option( $theme_version_option_name );
 
-		// If the 'hello_theme_version' option does not exist in the DB, or the version needs to be updated, do the update.
-		if ( ! $hello_theme_db_version || version_compare( $hello_theme_db_version, HELLO_ELEMENTOR_VERSION, '<' ) ) {
-			update_option( $theme_version_option_name, HELLO_ELEMENTOR_VERSION, true );
-		}
+	// If the 'hello_theme_version' option does not exist in the DB, or the version needs to be updated, do the update.
+	if ( ! $hello_theme_db_version || version_compare( $hello_theme_db_version, HELLO_ELEMENTOR_VERSION, '<' ) ) {
+		update_option( $theme_version_option_name, HELLO_ELEMENTOR_VERSION, true );
 	}
 }
 

--- a/includes/admin-functions.php
+++ b/includes/admin-functions.php
@@ -163,35 +163,3 @@ add_action( 'wp_ajax_hello_elementor_set_admin_notice_viewed', 'ajax_hello_eleme
 if ( ! did_action( 'elementor/loaded' ) ) {
 	add_action( 'admin_notices', 'hello_elementor_fail_load_admin_notice' );
 }
-
-/**
- * Set Theme Version
- *
- * @return void
- */
-add_action( 'after_switch_theme', 'hello_set_theme_ver', 100 );
-function hello_set_theme_ver() {
-	update_option( 'hello_theme_version', HELLO_ELEMENTOR_VERSION, true );
-}
-
-/**
- * Hello Check Theme Version
- *
- * Fired when the theme is updated, on the hook 'set_site_transient_update_themes'.
- * This method updates two database options: 'hello_theme_version', and potentially also 'hello_header_footer_experiment'.
- * 'hello_theme_version' is a new option that is added here in version 2.4.0.
- * If it does not exist in the database, it means the theme is upgraded to a >=2.4.0 version from a <2.4.0 version.
- * If the 'hello_theme_version' option has not been set, we default the new Hello Header & Footer experiment to 'inactive'.
- *
- * @since 2.4.0
- */
-add_action( 'set_site_transient_update_themes', 'hello_check_theme_ver', 100 );
-function hello_check_theme_ver() {
-	// If we don't have the theme version of Hello enabled, add it now, and make sure that we turn off the dynamic header
-	if ( ! get_option( 'hello_theme_version' ) ) {
-		update_option( 'hello_header_footer_experiment', 'inactive', true );
-	}
-
-	// Update the theme version
-	update_option( 'hello_theme_version', HELLO_ELEMENTOR_VERSION, true );
-}

--- a/includes/elementor-functions.php
+++ b/includes/elementor-functions.php
@@ -1,9 +1,5 @@
 <?php
 
-use Elementor\Plugin;
-use Elementor\Core\Kits\Documents\Kit;
-use Elementor\Core\Experiments\Manager as Experiments_Manager;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -19,7 +15,7 @@ function hello_elementor_settings_init() {
 		require 'settings/settings-header.php';
 		require 'settings/settings-footer.php';
 
-		add_action( 'elementor/kit/register_tabs', function( Kit $kit ) {
+		add_action( 'elementor/kit/register_tabs', function( \Elementor\Core\Kits\Documents\Kit $kit ) {
 			$kit->register_tab( 'hello-settings-header', HelloElementor\Includes\Settings\Settings_Header::class );
 			$kit->register_tab( 'hello-settings-footer', HelloElementor\Includes\Settings\Settings_Footer::class );
 		}, 1, 40 );
@@ -40,7 +36,7 @@ function hello_elementor_get_setting( $setting_id ) {
 	$return = '';
 
 	if ( ! isset( $hello_elementor_settings['kit_settings'] ) ) {
-		$kit = Plugin::$instance->documents->get( Plugin::$instance->kits_manager->get_active_id(), false );
+		$kit = \Elementor\Plugin::$instance->documents->get( \Elementor\Plugin::$instance->kits_manager->get_active_id(), false );
 		$hello_elementor_settings['kit_settings'] = $kit->get_settings();
 	}
 
@@ -151,7 +147,6 @@ add_action( 'elementor/editor/after_enqueue_scripts', function() {
 } );
 
 add_action( 'wp_enqueue_scripts', function() {
-
 	if ( ! hello_header_footer_experiment_active() ) {
 		return;
 	}
@@ -166,7 +161,7 @@ add_action( 'wp_enqueue_scripts', function() {
 		true
 	);
 
-	Elementor\Plugin::$instance->kits_manager->frontend_before_enqueue_styles();
+	\Elementor\Plugin::$instance->kits_manager->frontend_before_enqueue_styles();
 } );
 
 
@@ -206,15 +201,15 @@ function hello_get_footer_display() {
 /**
  * Add Hello Theme Header & Footer to Experiments.
  */
-add_action( 'elementor/experiments/default-features-registered', function( Experiments_Manager $experiments_manager ) {
+add_action( 'elementor/experiments/default-features-registered', function( \Elementor\Core\Experiments\Manager $experiments_manager ) {
 	$experiments_manager->add_feature( [
 		'name' => 'hello-theme-header-footer',
 		'title' => __( 'Hello Theme Header & Footer', 'hello-elementor' ),
 		'description' => sprintf( __( 'Use this experiment to design header and footer using Elementor Site Settings. <a href="%s" target="_blank">Learn More</a>', 'hello-elementor' ), 'https://go.elementor.com/wp-dash-header-footer' ),
-		'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
+		'release_status' => $experiments_manager::RELEASE_STATUS_BETA,
 		'new_site' => [
 			'minimum_installation_version' => '3.3.0',
-			'default_active' => Experiments_Manager::STATE_ACTIVE,
+			'default_active' => $experiments_manager::STATE_ACTIVE,
 		],
 	] );
 } );
@@ -228,9 +223,9 @@ function hello_header_footer_experiment_active() {
 		return false;
 	}
 	// Backwards compat.
-	if ( ! method_exists( Plugin::$instance->experiments, 'is_feature_active' ) ) {
+	if ( ! method_exists( \Elementor\Plugin::$instance->experiments, 'is_feature_active' ) ) {
 		return false;
 	}
 
-	return (bool) ( Plugin::$instance->experiments->is_feature_active( 'hello-theme-header-footer' ) );
+	return (bool) ( \Elementor\Plugin::$instance->experiments->is_feature_active( 'hello-theme-header-footer' ) );
 }

--- a/includes/elementor-functions.php
+++ b/includes/elementor-functions.php
@@ -212,7 +212,10 @@ add_action( 'elementor/experiments/default-features-registered', function( Exper
 		'title' => __( 'Hello Theme Header & Footer', 'hello-elementor' ),
 		'description' => sprintf( __( 'Use this experiment to design header and footer using Elementor Site Settings. <a href="%s" target="_blank">Learn More</a>', 'hello-elementor' ), 'https://go.elementor.com/wp-dash-header-footer' ),
 		'release_status' => Experiments_Manager::RELEASE_STATUS_BETA,
-		'default' => ( false === get_option( 'hello_header_footer_experiment' ) ? Experiments_Manager::STATE_ACTIVE : Experiments_Manager::STATE_INACTIVE ),
+		'new_site' => [
+			'minimum_installation_version' => '3.3.0',
+			'default_active' => Experiments_Manager::STATE_ACTIVE,
+		],
 	] );
 } );
 

--- a/includes/settings/settings-footer.php
+++ b/includes/settings/settings-footer.php
@@ -2,11 +2,9 @@
 
 namespace HelloElementor\Includes\Settings;
 
-use Elementor\Plugin;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Background;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Responsive\Responsive;
 use Elementor\Core\Kits\Documents\Tabs\Tab_Base;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -498,7 +496,7 @@ class Settings_Footer extends Tab_Base {
 					<img src="%4$s" class="elementor-nerd-box-icon">
 					<div class="elementor-nerd-box-message">
 						<p class="elementor-panel-heading-title elementor-nerd-box-title">%1$s</p>
-						<p class="elementor-nerd-box-message">%2$s</p>	
+						<p class="elementor-nerd-box-message">%2$s</p>
 					</div>
 					<a class="elementor-button elementor-button-success elementor-nerd-box-link" target="_blank" href="%5$s">%3$s</a>
 				</div>


### PR DESCRIPTION
Removed "theme switching" and "update transient" based hooks for determining whether the Header/Footer experiment should be active by default or not.

Instead, The experiment will be disabled by default if the user updated Hello Theme before installing Elementor v3.3.0. If Elementor v2.4.1 will be installed while Elementor 3.3.0 and up is installed, it will be active by default. Otherwise, it will be inactive by default.