### PR TITLE
Run GitHub Actions on latest version of ubuntu

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -5,7 +5,7 @@ on: [workflow_dispatch]
 jobs:
   bump-version:
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes') && startsWith(github.repository, 'elementor/')
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       prev_version: ${{ steps.bump_version_step.outputs.prev_version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
           bash "${GITHUB_WORKSPACE}/.github/scripts/commit-push-bump.sh"
   publish:
     needs: bump-version
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v2

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   bump-version:
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes') && startsWith(github.repository, 'elementor/')
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       prev_version: ${{ steps.bump_version_step.outputs.prev_version }}
     steps:
@@ -46,7 +46,7 @@ jobs:
           bash "${GITHUB_WORKSPACE}/.github/scripts/commit-push-bump.sh"
   publish:
     needs: bump-version
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   merge-release-branch-to-develop:
     if: (github.actor == 'ronkelementor' || github.actor == 'KingYes') && startsWith(github.repository, 'elementor/')
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{ secrets.MAINTAIN_TOKEN }}
   bump-version:
     needs: merge-release-branch-to-develop
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       prev_version: ${{ steps.bump_version_step.outputs.prev_version }}
     steps:
@@ -76,7 +76,7 @@ jobs:
           bash "${GITHUB_WORKSPACE}/.github/scripts/commit-push-bump.sh"
   publish:
     needs: bump-version
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
         uses: actions/checkout@v2

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: startsWith( github.repository, 'elementor/' )
     steps:
       - name: Checkout master branch


### PR DESCRIPTION
This should fix most of the actions which aren't currently running anymore due to the Ubuntu 16.04 runner no longer being supported.

This also allows dependabot to update GitHub Actions. If you'd rather not include this, I can always remove it.