### PR TITLE
Tweak: Remove backwards compatibility support for `wp_body_open()` [ED-9469]

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -205,16 +205,3 @@ if ( ! function_exists( 'hello_elementor_check_hide_title' ) ) {
 	}
 }
 add_filter( 'hello_elementor_page_title', 'hello_elementor_check_hide_title' );
-
-/**
- * Wrapper function to deal with backwards compatibility.
- */
-if ( ! function_exists( 'hello_elementor_body_open' ) ) {
-	function hello_elementor_body_open() {
-		if ( function_exists( 'wp_body_open' ) ) {
-			wp_body_open();
-		} else {
-			do_action( 'wp_body_open' );
-		}
-	}
-}

--- a/header.php
+++ b/header.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </head>
 <body <?php body_class(); ?>>
 
-<?php hello_elementor_body_open(); ?>
+<?php wp_body_open(); ?>
 
 <a class="skip-link screen-reader-text" href="#content">
 	<?php esc_html_e( 'Skip to content', 'hello-elementor' ); ?></a>


### PR DESCRIPTION
`wp_body_open()` was added in WordPress 5.2.

If the theme has a [minimum required versions of WordPress 5.3](https://github.com/elementor/hello-theme/pull/245), we no longer need the backwards compatibility functionality.