### PR TITLE
Tweak: Update minimum required WordPress version to 5.9 [ED-9466]

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -6,8 +6,8 @@
 	Author URI: https://elementor.com/?utm_source=wp-themes&utm_campaign=author-uri&utm_medium=wp-dash
 	Version: 2.6.1
 	Stable tag: 2.6.1
-	Requires at least: 4.7
-	Tested up to: 5.9
+	Requires at least: 5.9
+	Tested up to: 6.1
 	Requires PHP: 5.6
 	License: GNU General Public License v3 or later.
 	License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -22,7 +22,7 @@
 // Base CSS
 @import "reset/reset";
 
-// Forms/
+// Forms
 @import "reset/forms";
 
 // Table


### PR DESCRIPTION
Related: #247