### PR TITLE
Tweak: Check if posts have featured images set [ED-10057]

### DIFF
--- a/template-parts/archive.php
+++ b/template-parts/archive.php
@@ -28,7 +28,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<article class="post">
 				<?php
 				printf( '<h2 class="%s"><a href="%s">%s</a></h2>', 'entry-title', esc_url( $post_link ), wp_kses_post( get_the_title() ) );
-				printf( '<a href="%s">%s</a>', esc_url( $post_link ), get_the_post_thumbnail( $post, 'large' ) );
+				if ( has_post_thumbnail() ) {
+					printf( '<a href="%s">%s</a>', esc_url( $post_link ), get_the_post_thumbnail( $post, 'large' ) );
+				}
 				the_excerpt();
 				?>
 			</article>

--- a/template-parts/search.php
+++ b/template-parts/search.php
@@ -28,7 +28,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<article class="post">
 					<?php
 					printf( '<h2 class="%s"><a href="%s">%s</a></h2>', 'entry-title', esc_url( $post_link ), wp_kses_post( get_the_title() ) );
-					printf( '<a href="%s">%s</a>', esc_url( $post_link ), get_the_post_thumbnail( $post, 'large' ) );
+					if ( has_post_thumbnail() ) {
+						printf( '<a href="%s">%s</a>', esc_url( $post_link ), get_the_post_thumbnail( $post, 'large' ) );
+					}
 					the_excerpt();
 					?>
 				</article>


### PR DESCRIPTION
The theme has to check if a features images was set.

Why? because currently it the there is no featured image, the markup prints an empty link:

![image](https://user-images.githubusercontent.com/92088692/224061016-826074f9-33c0-4430-a923-617679986b92.png)

Empty link without and image bloats the markup.

In addition, it creates an a11y issue as with keyboard navigation, we have another link (empty link).