### PR TITLE
Tweak: Use theme CSS not Elementor plugins CSS [ED-10058]

### DIFF
--- a/template-parts/dynamic-header.php
+++ b/template-parts/dynamic-header.php
@@ -56,7 +56,7 @@ $header_nav_menu = wp_nav_menu( [
 			<div class="site-navigation-toggle-holder <?php echo esc_attr( hello_show_or_hide( 'hello_header_menu_display' ) ); ?>">
 				<div class="site-navigation-toggle" tabindex="0">
 					<i class="eicon-menu-bar" aria-hidden="true"></i>
-					<span class="elementor-screen-only">Menu</span>
+					<span class="screen-reader-text">Menu</span>
 				</div>
 			</div>
 			<nav class="site-navigation-dropdown <?php echo esc_attr( hello_show_or_hide( 'hello_header_menu_display' ) ); ?>">


### PR DESCRIPTION
The dynamic header menu assumes Elementor plugin is installed and uses the `.elementor-screen-only` CSS class.

It should not assume the plugin installed, and use the `.screen-reader-text` CSS class which is already defined in the theme.