### PR TITLE
Tweak: Match autoprefixer browsers list settings to Elementor plugin [ED-10094]

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function( grunt ) {
 
 					processors: [
 						require( 'autoprefixer' )( {
-							browsers: 'last 3 versions',
+							browsers: [ 'last 3 versions', 'not dead' ],
 						} ),
 					],
 				},
@@ -55,7 +55,7 @@ module.exports = function( grunt ) {
 				options: {
 					processors: [
 						require( 'autoprefixer' )( {
-							browsers: 'last 3 versions',
+							browsers: [ 'last 3 versions', 'not dead' ],
 						} ),
 						require( 'cssnano' )( {
 							reduceIdents: false,


### PR DESCRIPTION
Elementor uses the following autoprefixer settings:

```
last 3 versions
not dead
```

While Hello theme uses only:

```
last 3 versions
```

We should match the settings.