### PR TITLE
Tweak: Delete filter hooks deprecated in version 2.0 [ED-10185]

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,19 +26,16 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 			hello_maybe_update_theme_version_in_db();
 		}
 
-		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_load_textdomain', [ true ], '2.0', 'hello_elementor_load_textdomain' );
-		if ( apply_filters( 'hello_elementor_load_textdomain', $hook_result ) ) {
+		if ( apply_filters( 'hello_elementor_load_textdomain', true ) ) {
 			load_theme_textdomain( 'hello-elementor', get_template_directory() . '/languages' );
 		}
 
-		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_register_menus', [ true ], '2.0', 'hello_elementor_register_menus' );
-		if ( apply_filters( 'hello_elementor_register_menus', $hook_result ) ) {
+		if ( apply_filters( 'hello_elementor_register_menus', true ) ) {
 			register_nav_menus( [ 'menu-1' => esc_html__( 'Header', 'hello-elementor' ) ] );
 			register_nav_menus( [ 'menu-2' => esc_html__( 'Footer', 'hello-elementor' ) ] );
 		}
 
-		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_add_theme_support', [ true ], '2.0', 'hello_elementor_add_theme_support' );
-		if ( apply_filters( 'hello_elementor_add_theme_support', $hook_result ) ) {
+		if ( apply_filters( 'hello_elementor_add_theme_support', true ) ) {
 			add_theme_support( 'post-thumbnails' );
 			add_theme_support( 'automatic-feed-links' );
 			add_theme_support( 'title-tag' );
@@ -77,8 +74,7 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 			/*
 			 * WooCommerce.
 			 */
-			$hook_result = apply_filters_deprecated( 'elementor_hello_theme_add_woocommerce_support', [ true ], '2.0', 'hello_elementor_add_woocommerce_support' );
-			if ( apply_filters( 'hello_elementor_add_woocommerce_support', $hook_result ) ) {
+			if ( apply_filters( 'hello_elementor_add_woocommerce_support', true ) ) {
 				// WooCommerce in general.
 				add_theme_support( 'woocommerce' );
 				// Enabling WooCommerce product gallery features (are off by default since WC 3.0.0).
@@ -112,10 +108,9 @@ if ( ! function_exists( 'hello_elementor_scripts_styles' ) ) {
 	 * @return void
 	 */
 	function hello_elementor_scripts_styles() {
-		$enqueue_basic_style = apply_filters_deprecated( 'elementor_hello_theme_enqueue_style', [ true ], '2.0', 'hello_elementor_enqueue_style' );
-		$min_suffix          = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$min_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		if ( apply_filters( 'hello_elementor_enqueue_style', $enqueue_basic_style ) ) {
+		if ( apply_filters( 'hello_elementor_enqueue_style', true ) ) {
 			wp_enqueue_style(
 				'hello-elementor',
 				get_template_directory_uri() . '/style' . $min_suffix . '.css',
@@ -145,8 +140,7 @@ if ( ! function_exists( 'hello_elementor_register_elementor_locations' ) ) {
 	 * @return void
 	 */
 	function hello_elementor_register_elementor_locations( $elementor_theme_manager ) {
-		$hook_result = apply_filters_deprecated( 'elementor_hello_theme_register_elementor_locations', [ true ], '2.0', 'hello_elementor_register_elementor_locations' );
-		if ( apply_filters( 'hello_elementor_register_elementor_locations', $hook_result ) ) {
+		if ( apply_filters( 'hello_elementor_register_elementor_locations', true ) ) {
 			$elementor_theme_manager->register_all_core_location();
 		}
 	}


### PR DESCRIPTION
The `functions.php` file has 6 deprecated filter hooks which were renamed in version 2.0 (release on 2019-05-12), almost 4 years ago.

It is time to delete the deprecated filter hooks.