### PR TITLE
Tweak: Link to Elementor "Site Identity" panel from the header & footer panels [ED-10224]

### DIFF
--- a/includes/settings/settings-footer.php
+++ b/includes/settings/settings-footer.php
@@ -214,7 +214,11 @@ class Settings_Footer extends Tab_Base {
 			[
 				'type' => Controls_Manager::SLIDER,
 				'label' => esc_html__( 'Logo Width', 'hello-elementor' ),
-				'description' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s logo', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'description' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s logo', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'size_units' => [ '%', 'px', 'em', 'rem', 'vw', 'custom' ],
 				'range' => [
 					'px' => [
@@ -270,7 +274,11 @@ class Settings_Footer extends Tab_Base {
 			'hello_footer_title_link',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title and tagline', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'raw' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'content_classes' => 'elementor-control-field-description',
 				'condition' => [
 					'hello_footer_logo_display' => 'yes',
@@ -322,7 +330,11 @@ class Settings_Footer extends Tab_Base {
 			'hello_footer_tagline_link',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title and tagline', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'raw' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s tagline', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'content_classes' => 'elementor-control-field-description',
 			]
 		);

--- a/includes/settings/settings-header.php
+++ b/includes/settings/settings-header.php
@@ -217,7 +217,11 @@ class Settings_Header extends Tab_Base {
 			[
 				'type' => Controls_Manager::SLIDER,
 				'label' => esc_html__( 'Logo Width', 'hello-elementor' ),
-				'description' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s logo', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'description' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s logo', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'size_units' => [ '%', 'px', 'em', 'rem', 'vw', 'custom' ],
 				'range' => [
 					'px' => [
@@ -260,7 +264,11 @@ class Settings_Header extends Tab_Base {
 			[
 				'name' => 'hello_header_title_typography',
 				'label' => esc_html__( 'Typography', 'hello-elementor' ),
-				'description' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title and tagline', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'description' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'condition' => [
 					'hello_header_logo_display' => 'yes',
 					'hello_header_logo_type' => 'title',
@@ -273,7 +281,11 @@ class Settings_Header extends Tab_Base {
 			'hello_header_title_link',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title and tagline', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'raw' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'content_classes' => 'elementor-control-field-description',
 				'condition' => [
 					'hello_header_logo_display' => 'yes',
@@ -332,7 +344,11 @@ class Settings_Header extends Tab_Base {
 			'hello_header_tagline_link',
 			[
 				'type' => Controls_Manager::RAW_HTML,
-				'raw' => sprintf( __( 'Go to <a href="%s">Site Identity</a> to manage your site\'s title and tagline', 'hello-elementor' ), wp_nonce_url( 'customize.php?autofocus[section]=title_tagline' ) ),
+				'raw' => sprintf(
+					/* translators: %s: Link that opens Elementor's "Site Identity" panel. */
+					__( 'Go to <a href="%s">Site Identity</a> to manage your site\'s tagline', 'hello-elementor' ),
+					"javascript:\$e.route('panel/global/settings-site-identity')"
+				),
 				'content_classes' => 'elementor-control-field-description',
 			]
 		);


### PR DESCRIPTION
Hello Theme adds Header and Footer setting to the “Site Settings” panel.

The panels link to WordPress Customizer to allow the user to update the site title, tagline and logo.

It should link to Elementor “Site Identity” panel instead.