### PR TITLE
Tweak: Delete `hello_elementor_load_textdomain` filter hook [ED-10229]

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Source: https://stocksnap.io/photo/4B83RD7BV9
 * Tweak: Delete deprecated `elementor_hello_theme_enqueue_style` filter hook
 * Tweak: Delete deprecated `elementor_hello_theme_register_elementor_locations` filter hook
 * Tweak: Added additional and `custom` units to header & footer panels
+* Tweak: Link to Elementor "Site Identity" panel from the header & footer panels
+* Tweak: Delete the `hello_elementor_load_textdomain` filter hook
 
 ### 2.6.1 - 2022-07-11 ###
 * Tweak: Tables looks weird on dark backgrounds ([#126](https://github.com/elementor/hello-theme/issues/126))

--- a/functions.php
+++ b/functions.php
@@ -26,10 +26,6 @@ if ( ! function_exists( 'hello_elementor_setup' ) ) {
 			hello_maybe_update_theme_version_in_db();
 		}
 
-		if ( apply_filters( 'hello_elementor_load_textdomain', true ) ) {
-			load_theme_textdomain( 'hello-elementor', get_template_directory() . '/languages' );
-		}
-
 		if ( apply_filters( 'hello_elementor_register_menus', true ) ) {
 			register_nav_menus( [ 'menu-1' => esc_html__( 'Header', 'hello-elementor' ) ] );
 			register_nav_menus( [ 'menu-2' => esc_html__( 'Footer', 'hello-elementor' ) ] );

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,8 @@ Source: https://stocksnap.io/photo/4B83RD7BV9
 * Tweak: Delete deprecated `elementor_hello_theme_enqueue_style` filter hook
 * Tweak: Delete deprecated `elementor_hello_theme_register_elementor_locations` filter hook
 * Tweak: Added additional and `custom` units to header & footer panels
+* Tweak: Link to Elementor "Site Identity" panel from the header & footer panels
+* Tweak: Delete the `hello_elementor_load_textdomain` filter hook
 
 = 2.6.1 - 2022-07-11 =
 * Tweak: Tables looks weird on dark backgrounds ([#126](https://github.com/elementor/hello-theme/issues/126))


### PR DESCRIPTION
In the past WordPress themes/plugins included the translation files (`*.po` & `*.mo`) in the `languages` folder.

WordPress moved all the translations files to [translate.wordpress.org](http://translate.wordpress.org/) to simplify the translation process.

The Hello theme no longer need to call the `load_theme_textdomain()` function to load the translation files from the them folder. Besides, we load PO and MO files from the languages folder, but there are no PO and MO files there.

We can safely delete the `hello_elementor_load_textdomain` filter hook and the `load_theme_textdomain()` function it activates.