### PR TITLE
Tweak: Remove duplicate CSS classes for screen readers [ED-10558]

### DIFF
--- a/assets/scss/reset/_reset.scss
+++ b/assets/scss/reset/_reset.scss
@@ -257,17 +257,6 @@ template {
 	display: none;
 }
 
-.sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	white-space: nowrap;
-	border: 0;
-}
-
 /* Print
  */
 


### PR DESCRIPTION
The theme has two similar CSS classes:

* `.sr-only` - not in use.
* `.screen-reader-text` - used in skip links and menu toggle button.

The second one is a modern classes using the latest best practices. We should delete the first, unused, class.