### PR TITLE
Tweak: Replace legacy `page-break-*` CSS properties with `break-*` properties [ED-10559]

### DIFF
--- a/assets/scss/reset/_reset.scss
+++ b/assets/scss/reset/_reset.scss
@@ -303,9 +303,10 @@ template {
 	pre {
 		white-space: pre-wrap !important;
 	}
+
 	pre,
 	blockquote {
-		page-break-inside: avoid;
+		break-inside: avoid;
 		border: 1px solid $gray-light;
 	}
 
@@ -315,7 +316,7 @@ template {
 
 	tr,
 	img {
-		page-break-inside: avoid;
+		break-inside: avoid;
 	}
 
 	p,
@@ -327,6 +328,6 @@ template {
 
 	h2,
 	h3 {
-		page-break-after: avoid;
+		break-after: avoid;
 	}
 }


### PR DESCRIPTION
The theme uses the following legacy CSS properties:

* `page-break-inside`
* `page-break-after`

They were replaced with newer CSS properties:

* `break-inside`
* `break-after`