### PR TITLE
Tweak: Update `Tested up to 6.5` [ED-14565]

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -7,7 +7,7 @@
 	Version: 3.0.1
 	Stable tag: 3.0.1
 	Requires at least: 6.0
-	Tested up to: 6.4
+	Tested up to: 6.5
 	Requires PHP: 7.3
 	License: GNU General Public License v3 or later.
 	License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: elemntor, KingYes, ariel.k, bainternet
 Requires at least: 6.0
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 3.0.1
 Version: 3.0.1
 Requires PHP: 7.3


### PR DESCRIPTION
Currently, the theme tested up to WordPress 6.4, but WordPress 6.5 already released. We need to update.