### PR TITLE
Submenu fix on mobile phone

### DIFF
--- a/assets/dev/js/frontend/hello-frontend.js
+++ b/assets/dev/js/frontend/hello-frontend.js
@@ -67,6 +67,9 @@ class elementorHelloThemeHandler {
         }
 
         parentLi.classList.toggle( 'elementor-active' );
+		if(parentLi.classList.contains('elementor-active')){
+  			event.preventDefault();
+		}
     }
 }
 


### PR DESCRIPTION
Allows the submenu to open without the parent link getting clicked on mobile phone
Fixes 
https://github.com/elementor/hello-theme/issues/316