### PR TITLE
Tweak: Update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build
         run: npm run zip
       - name: Upload zip file to GitHub actions artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: hello-elementor
           path: hello-elementor

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -80,7 +80,7 @@ jobs:
 
           npm run zip
       - name: Upload zip file to GitHub actions artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: hello-elementor.${{ env.PACKAGE_VERSION }}
           path: hello-elementor.*.zip

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -78,7 +78,7 @@ jobs:
           PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: npm run zip
       - name: Upload zip file to GitHub actions artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: hello-elementor.${{ env.PACKAGE_VERSION }}
           path: hello-elementor.*.zip

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,7 +105,7 @@ jobs:
           PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
         run: npm run zip
       - name: Upload zip file to GitHub actions artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: hello-elementor.${{ env.PACKAGE_VERSION }}
           path: hello-elementor.*.zip


### PR DESCRIPTION
The title explains everything :)

`actions/upload-artifact` should be updated to v4, because v2 is deprecated now and v3 will deprecated soon.

This will fix the following error in the [latest build](https://github.com/elementor/hello-theme/actions/runs/11663178694/job/32471066264):
`Error: This request has been automatically failed because it uses a deprecated version of 'actions/upload-artifact: v2'. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/`