### PR TITLE
Internal: Revert playwright config for Daily Matrix [TMZ-905]

### DIFF
--- a/.github/workflows/playwright-with-specific-elementor-version.yml
+++ b/.github/workflows/playwright-with-specific-elementor-version.yml
@@ -402,8 +402,7 @@ jobs:
           export DAILY_MATRIX_WORKFLOW=true
           echo "🧪 Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
           # Only run Hello Theme tests, not Elementor or other plugin tests
-          # Use Daily Matrix specific config that excludes problematic tests
-          npx playwright test -c tests/playwright/playwright.daily-matrix.config.ts
+          npm run test:playwright -- tests/playwright/tests/
           
       - name: Skip tests - version incompatible
         if: steps.extract-version-tests.outputs.tests-available != 'true'
@@ -662,8 +661,8 @@ jobs:
         run: |
           export DAILY_MATRIX_WORKFLOW=true
           echo "🧪 Running tagged tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
-          # Only run Hello Theme tests with the specified tag using Daily Matrix config
-          npx playwright test -c tests/playwright/playwright.daily-matrix.config.ts --grep="${{ github.event.inputs.tag }}"
+          # Only run Hello Theme tests with the specified tag
+          npm run test:playwright -- tests/playwright/tests/ --grep="${{ github.event.inputs.tag }}"
           
       - name: Skip tagged tests - version incompatible
         if: steps.extract-version-tests.outputs.tests-available != 'true'


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Revert to standard Playwright test commands for Daily Matrix workflow by removing custom configuration.
Main changes:
- Replaced custom Playwright daily matrix config with standard npm test command for regular tests
- Updated tagged tests execution to use standard npm command with grep option instead of custom config

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
