### PR TITLE
Tweak: Show PLG only on selected pages [TMZ-919]

### DIFF
--- a/.buildignore
+++ b/.buildignore
@@ -32,3 +32,4 @@ tsconfig.json
 .wp-env.json
 .phpunit.result.cache
 temp-changelog-from-readme.txt
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "phpcs.standard": "./phpcs.xml",
+  "phpcs.executablePath": "vendor/bin/phpcs",
+  "phpcbf.executablePath": "vendor/bin/phpcbf",
+  "phpcs.enable": true,
+  "phpcbf.enable": true,
+  "phpcs.showSources": true
+}

--- a/composer.json
+++ b/composer.json
@@ -3,23 +3,23 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.6",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-	  	"wp-coding-standards/wpcs": "^2.3",
-		"phpunit/phpunit": "9.5.14",
-		"elementor/elementor-editor-testing": "0.0.3",
-		"yoast/phpunit-polyfills": "^1.0.1"
-	},
-	"require": {
-		"elementor/wp-notifications-package": "1.2.*"
-	},
-	"config": {
-		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
-	},
+        "wp-coding-standards/wpcs": "^2.3",
+        "phpunit/phpunit": "9.5.14",
+        "elementor/elementor-editor-testing": "0.0.3",
+        "yoast/phpunit-polyfills": "^1.0.1"
+    },
+    "require": {
+        "elementor/wp-notifications-package": "1.2.*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
     "scripts": {
-        "lint": "phpcs --extensions=php -p",
-		"lint:fix": "vendor/bin/phpcbf --ignore=node_modules,vendor,build .",
-		"test": "phpunit --testsuite hello-elementor",
-		"test:install": "bash ./bin/install-wp-tests-local.sh"
+        "lint": "phpcs --extensions=php --standard=./phpcs.xml --ignore=node_modules,vendor,assets,tmp -p .",
+        "lint:fix": "vendor/bin/phpcbf --extensions=php --standard=./phpcs.xml --ignore=node_modules,vendor,assets,tmp .",
+        "test": "phpunit --testsuite hello-elementor",
+        "test:install": "bash ./bin/install-wp-tests-local.sh"
     }
 }

--- a/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
+++ b/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
@@ -20,21 +20,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const container = document.getElementById( 'ehe-admin-cb' );
 
 	if ( container ) {
-		let headerEnd = document.querySelector( '.wp-header-end' );
-
-		if ( ! headerEnd ) {
-			headerEnd = document.querySelector( '.wrap h1, .wrap h2' );
-		}
+        const { beforeWrap = false } = window.ehe_cb;
+        const { selector, before = false } = window.ehe_cb.data;
+		const headerEnd = document.querySelector( selector );
 
 		if ( headerEnd ) {
-			if ( window.ehe_cb.beforeWrap ) {
+			if ( beforeWrap ) {
 				const wrapElement = document.querySelector( '.wrap' );
 				if ( wrapElement ) {
 					wrapElement.insertAdjacentElement( 'beforebegin', container );
 				}
-			} else {
-				headerEnd.insertAdjacentElement( 'afterend', container );
-			}
+			} else if ( before ) {
+                headerEnd.insertAdjacentElement( 'beforebegin', container );
+            } else {
+                headerEnd.insertAdjacentElement( 'afterend', container );
+            }
 		}
 
 		const root = createRoot( container );

--- a/modules/admin-home/components/conversion-banner.php
+++ b/modules/admin-home/components/conversion-banner.php
@@ -18,21 +18,143 @@ class Conversion_Banner {
 		<?php
 	}
 
-	private function is_conversion_banner_active(): bool {
+	private function get_allowed_admin_pages(): array {
+		return [
+			'dashboard' => [ 'selector' => '#wpbody #wpbody-content .wrap h1' ],
+			'update-core' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'edit-post' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'edit-category' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'edit-post_tag' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'upload' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'media' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'edit-page' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'elementor_page_elementor-settings' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'edit-elementor_library' => [
+                'selector' => '.wrap h1, .wrap h2',
+                'before' => true,
+            ],
+			'elementor_page_elementor-tools' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'elementor_page_elementor-role-manager' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'elementor_page_elementor-element-manager' => [
+                'selector' => '.wrap h1, .wrap h3.wp-heading-inline',
+            ],
+			'elementor_page_elementor-system-info' => [
+                'selector' => '#wpbody #wpbody-content #elementor-system-info .elementor-system-info-header',
+                'before' => true,
+            ],
+			'elementor_library_page_e-floating-buttons' => [
+                'selector' => '#wpbody-content .e-landing-pages-empty, .wrap h2',
+                'before' => true,
+            ],
+            'edit-e-floating-buttons' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'edit-elementor_library_category' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'themes' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'nav-menus' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'theme-editor' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'plugins' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'plugin-install' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'plugin-editor' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'users' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'user' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'profile' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'tools' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'import' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'export' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'site-health' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'export-personal-data' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'erase-personal-data' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-general' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-writing' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-reading' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-discussion' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-media' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-permalink' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'options-privacy' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+			'privacy-policy-guide' => [
+                'selector' => '.wrap h1, .wrap h2',
+            ],
+		];
+	}
+
+	private function is_allowed_admin_page(): array {
+		$current_screen = get_current_screen();
+		
+		if ( ! $current_screen ) {
+			return [];
+		}
+
+		$allowed_pages = $this->get_allowed_admin_pages();
+		$current_page = $current_screen->id;
+        error_log( print_r( $current_page, true ) );
+
+		return $allowed_pages[ $current_page ] ?? [];
+	}
+
+	private function is_conversion_banner_active(): array {
 		if ( get_user_meta( get_current_user_id(), '_hello_elementor_install_notice', true ) ) {
-			return false;
+			return [];
 		}
 
 		if ( Utils::has_pro() && Utils::is_elementor_active() ) {
-			return false;
+			return [];
 		}
 
-		$current_screen = get_current_screen();
-
-		return false === strpos( $current_screen->id ?? '', EHP_THEME_SLUG );
+		return $this->is_allowed_admin_page();
 	}
 
-	private function enqueue_scripts() {
+	private function enqueue_scripts( array $conversion_banner_active ) {
 		$script = new Script(
 			'hello-conversion-banner',
 			[ 'wp-util' ]
@@ -48,6 +170,7 @@ class Conversion_Banner {
 			[
 				'nonce' => wp_create_nonce( 'ehe_cb_nonce' ),
 				'beforeWrap' => $is_installing_plugin_with_uploader,
+                'data' => $conversion_banner_active,
 			]
 		);
 	}
@@ -65,7 +188,8 @@ class Conversion_Banner {
 		add_action( 'wp_ajax_ehe_dismiss_theme_notice', [ $this, 'dismiss_theme_notice' ] );
 
 		add_action( 'current_screen', function () {
-			if ( ! $this->is_conversion_banner_active() ) {
+            $conversion_banner_active = $this->is_conversion_banner_active();
+			if ( ! $conversion_banner_active ) {
 				return;
 			}
 
@@ -73,8 +197,8 @@ class Conversion_Banner {
 				$this->render_conversion_banner();
 			}, 11 );
 
-			add_action( 'admin_enqueue_scripts', function () {
-				$this->enqueue_scripts();
+			add_action( 'admin_enqueue_scripts', function () use ( $conversion_banner_active ) {
+				$this->enqueue_scripts( $conversion_banner_active );
 			} );
 		} );
 	}

--- a/modules/admin-home/components/conversion-banner.php
+++ b/modules/admin-home/components/conversion-banner.php
@@ -11,6 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Conversion_Banner {
 
+	const DEFAULT_SELECTOR = '.wrap h1, .wrap h2';
+	const SCRIPT_HANDLE = 'hello-conversion-banner';
+	const NONCE_ACTION = 'ehe_cb_nonce';
+	const OBJECT_NAME = 'ehe_cb';
+	const USER_META_KEY = '_hello_elementor_install_notice';
+	const AJAX_ACTION = 'ehe_dismiss_theme_notice';
+
 	private function render_conversion_banner() {
 		?>
 		<div id="ehe-admin-cb" style="width: calc(100% - 48px)">
@@ -21,23 +28,23 @@ class Conversion_Banner {
 	private function get_allowed_admin_pages(): array {
 		return [
 			'dashboard' => [ 'selector' => '#wpbody #wpbody-content .wrap h1' ],
-			'update-core' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'edit-post' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'edit-category' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'edit-post_tag' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'upload' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'media' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'edit-page' => [ 'selector' => '.wrap h1, .wrap h2' ],
-			'elementor_page_elementor-settings' => [ 'selector' => '.wrap h1, .wrap h2' ],
+			'update-core' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'edit-post' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'edit-category' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'edit-post_tag' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'upload' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'media' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'edit-page' => [ 'selector' => self::DEFAULT_SELECTOR ],
+			'elementor_page_elementor-settings' => [ 'selector' => self::DEFAULT_SELECTOR ],
 			'edit-elementor_library' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 				'before' => true,
 			],
 			'elementor_page_elementor-tools' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'elementor_page_elementor-role-manager' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'elementor_page_elementor-element-manager' => [
 				'selector' => '.wrap h1, .wrap h3.wp-heading-inline',
@@ -51,79 +58,79 @@ class Conversion_Banner {
 				'before' => true,
 			],
 			'edit-e-floating-buttons' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'edit-elementor_library_category' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'themes' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'nav-menus' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'theme-editor' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'plugins' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'plugin-install' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'plugin-editor' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'users' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'user' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'profile' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'tools' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'import' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'export' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'site-health' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'export-personal-data' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'erase-personal-data' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-general' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-writing' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-reading' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-discussion' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-media' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-permalink' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'options-privacy' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 			'privacy-policy-guide' => [
-				'selector' => '.wrap h1, .wrap h2',
+				'selector' => self::DEFAULT_SELECTOR,
 			],
 		];
 	}
@@ -142,7 +149,7 @@ class Conversion_Banner {
 	}
 
 	private function is_conversion_banner_active(): array {
-		if ( get_user_meta( get_current_user_id(), '_hello_elementor_install_notice', true ) ) {
+		if ( get_user_meta( get_current_user_id(), self::USER_META_KEY, true ) ) {
 			return [];
 		}
 
@@ -155,7 +162,7 @@ class Conversion_Banner {
 
 	private function enqueue_scripts( array $conversion_banner_active ) {
 		$script = new Script(
-			'hello-conversion-banner',
+			self::SCRIPT_HANDLE,
 			[ 'wp-util' ]
 		);
 
@@ -164,10 +171,10 @@ class Conversion_Banner {
 		$is_installing_plugin_with_uploader = 'upload-plugin' === filter_input( INPUT_GET, 'action', FILTER_UNSAFE_RAW );
 
 		wp_localize_script(
-			'hello-conversion-banner',
-			'ehe_cb',
+			self::SCRIPT_HANDLE,
+			self::OBJECT_NAME,
 			[
-				'nonce' => wp_create_nonce( 'ehe_cb_nonce' ),
+				'nonce' => wp_create_nonce( self::NONCE_ACTION ),
 				'beforeWrap' => $is_installing_plugin_with_uploader,
 				'data' => $conversion_banner_active,
 			]
@@ -175,16 +182,16 @@ class Conversion_Banner {
 	}
 
 	public function dismiss_theme_notice() {
-		check_ajax_referer( 'ehe_cb_nonce', 'nonce' );
+		check_ajax_referer( self::NONCE_ACTION, 'nonce' );
 
-		update_user_meta( get_current_user_id(), '_hello_elementor_install_notice', true );
+		update_user_meta( get_current_user_id(), self::USER_META_KEY, true );
 
 		wp_send_json_success( [ 'message' => __( 'Notice dismissed.', 'hello-elementor' ) ] );
 	}
 
 	public function __construct() {
 
-		add_action( 'wp_ajax_ehe_dismiss_theme_notice', [ $this, 'dismiss_theme_notice' ] );
+		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ $this, 'dismiss_theme_notice' ] );
 
 		add_action( 'current_screen', function () {
 			$conversion_banner_active = $this->is_conversion_banner_active();

--- a/modules/admin-home/components/conversion-banner.php
+++ b/modules/admin-home/components/conversion-banner.php
@@ -30,114 +30,113 @@ class Conversion_Banner {
 			'edit-page' => [ 'selector' => '.wrap h1, .wrap h2' ],
 			'elementor_page_elementor-settings' => [ 'selector' => '.wrap h1, .wrap h2' ],
 			'edit-elementor_library' => [
-                'selector' => '.wrap h1, .wrap h2',
-                'before' => true,
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+				'before' => true,
+			],
 			'elementor_page_elementor-tools' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'elementor_page_elementor-role-manager' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'elementor_page_elementor-element-manager' => [
-                'selector' => '.wrap h1, .wrap h3.wp-heading-inline',
-            ],
+				'selector' => '.wrap h1, .wrap h3.wp-heading-inline',
+			],
 			'elementor_page_elementor-system-info' => [
-                'selector' => '#wpbody #wpbody-content #elementor-system-info .elementor-system-info-header',
-                'before' => true,
-            ],
+				'selector' => '#wpbody #wpbody-content #elementor-system-info .elementor-system-info-header',
+				'before' => true,
+			],
 			'elementor_library_page_e-floating-buttons' => [
-                'selector' => '#wpbody-content .e-landing-pages-empty, .wrap h2',
-                'before' => true,
-            ],
-            'edit-e-floating-buttons' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '#wpbody-content .e-landing-pages-empty, .wrap h2',
+				'before' => true,
+			],
+			'edit-e-floating-buttons' => [
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'edit-elementor_library_category' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'themes' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'nav-menus' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'theme-editor' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'plugins' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'plugin-install' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'plugin-editor' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'users' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'user' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'profile' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'tools' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'import' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'export' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'site-health' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'export-personal-data' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'erase-personal-data' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-general' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-writing' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-reading' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-discussion' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-media' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-permalink' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'options-privacy' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 			'privacy-policy-guide' => [
-                'selector' => '.wrap h1, .wrap h2',
-            ],
+				'selector' => '.wrap h1, .wrap h2',
+			],
 		];
 	}
 
 	private function is_allowed_admin_page(): array {
 		$current_screen = get_current_screen();
-		
+
 		if ( ! $current_screen ) {
 			return [];
 		}
 
 		$allowed_pages = $this->get_allowed_admin_pages();
 		$current_page = $current_screen->id;
-        error_log( print_r( $current_page, true ) );
 
 		return $allowed_pages[ $current_page ] ?? [];
 	}
@@ -170,7 +169,7 @@ class Conversion_Banner {
 			[
 				'nonce' => wp_create_nonce( 'ehe_cb_nonce' ),
 				'beforeWrap' => $is_installing_plugin_with_uploader,
-                'data' => $conversion_banner_active,
+				'data' => $conversion_banner_active,
 			]
 		);
 	}
@@ -188,7 +187,7 @@ class Conversion_Banner {
 		add_action( 'wp_ajax_ehe_dismiss_theme_notice', [ $this, 'dismiss_theme_notice' ] );
 
 		add_action( 'current_screen', function () {
-            $conversion_banner_active = $this->is_conversion_banner_active();
+			$conversion_banner_active = $this->is_conversion_banner_active();
 			if ( ! $conversion_banner_active ) {
 				return;
 			}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -40,7 +40,7 @@
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_wp_version" value="4.7" />
+			<property name="minimum_supported_version" value="4.7" />
 		</properties>
 	</rule>
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -40,7 +40,7 @@
 
 	<rule ref="WordPress.WP.DeprecatedFunctions">
 		<properties>
-			<property name="minimum_supported_version" value="4.7" />
+			<property name="minimum_wp_version" value="4.7" />
 		</properties>
 	</rule>
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,8 +65,8 @@ if (!defined('WP_ADMIN')) {
 
 do_action('plugins_loaded');
 
-function initialize_elementor_plugin($plugin_class)
-{
+function initialize_elementor_plugin($plugin_class){
+
 	if (!class_exists($plugin_class)) {
 		return null;
 	}
@@ -75,8 +75,6 @@ function initialize_elementor_plugin($plugin_class)
 }
 
 $plugin_instance = initialize_elementor_plugin('Elementor\Plugin');
-
-$plugin_instance->initialize_container();
 
 do_action('init');
 do_action('wp_loaded');


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor PLG (Product Lead Generation) conversion banner to display only on specific admin pages with targeted placement.
Main changes:
- Added whitelist of admin pages with custom CSS selectors for banner placement
- Implemented conditional rendering logic with before/after positioning options
- Added constants for script handles, nonce actions, and user meta keys
- Updated JS implementation to use page-specific selectors

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
