### PR TITLE
New: Add theme home to Finder [TMZ-935]

### DIFF
--- a/modules/admin-home/components/finder.php
+++ b/modules/admin-home/components/finder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace HelloTheme\Modules\AdminHome\Components;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Finder {
+
+	public function add_hello_theme_finder_entry( $categories_data ) {
+		if ( isset( $categories_data['site'] ) && isset( $categories_data['site']['items'] ) ) {
+			$categories_data['site']['items']['hello-elementor-home'] = [
+				'title' => esc_html__( 'Hello Theme Home', 'hello-elementor' ),
+				'icon' => 'paint-brush',
+				'url' => admin_url( 'admin.php?page=hello-elementor' ),
+				'keywords' => [ 'theme', 'hello', 'home', 'plus', '+' ],
+			];
+		}
+
+		return $categories_data;
+	}
+
+	public function __construct() {
+		add_filter( 'elementor/finder/categories', [ $this, 'add_hello_theme_finder_entry' ] );
+	}
+}

--- a/modules/admin-home/module.php
+++ b/modules/admin-home/module.php
@@ -35,6 +35,7 @@ class Module extends Module_Base {
 			'Admin_Top_Bar',
 			'Settings_Controller',
 			'Notificator',
+			'Finder',
 		];
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add theme home entry to Elementor Finder functionality for improved theme navigation and accessibility.
Main changes:
- Created new Finder class to integrate Hello Theme Home entry into Elementor Finder categories
- Added Finder component to the Admin Home module components list
- Implemented filter hook to display Hello Theme Home in the site category of Elementor Finder

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
