### PR TITLE
Tweak: Remove welcome banner from home [TMZ-919]

### DIFF
--- a/modules/admin-home/assets/js/components/paper/welcome.js
+++ b/modules/admin-home/assets/js/components/paper/welcome.js
@@ -48,6 +48,8 @@ export const Welcome = ( { sx, dismissable = false } ) => {
 						await wp.ajax.post( 'ehe_dismiss_theme_notice', { nonce: window.ehe_cb.nonce } );
 						setVisible( false );
 					} catch ( e ) {
+						// eslint-disable-next-line no-console
+						console.error( e );
 					}
 				} }>
 					<Box component="span" className="screen-reader-text">{ __( 'Dismiss this notice.', 'hello-elementor' ) }</Box>

--- a/modules/admin-home/assets/js/pages/admin-page.js
+++ b/modules/admin-home/assets/js/pages/admin-page.js
@@ -5,7 +5,6 @@ import { ThemeProvider } from '@elementor/ui/styles';
 import { GridWithActionLinks } from '../layouts/grids/grid-with-action-links';
 import Stack from '@elementor/ui/Stack';
 import { QuickLinks } from '../components/paper/quick-links';
-import { Welcome } from '../components/paper/welcome';
 import { SiteParts } from '../components/paper/site-parts';
 import { Resources } from '../components/paper/resources';
 
@@ -15,9 +14,6 @@ export const AdminPage = () => {
 			<Box className="hello_plus__notices" component="div">
 			</Box>
 			<Box>
-				<Box sx={ { mb: 2 } }>
-					<Welcome />
-				</Box>
 				<GridWithActionLinks>
 					<Stack direction="column" gap={ 2 }>
 						<QuickLinks />


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove welcome banner component from admin home page to simplify the user interface.
Main changes:
- Removed Welcome component import and related rendering code from admin-page.js
- Added error logging in welcome.js when dismissal API call fails

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
