### PR TITLE
Internal: Add Slack notification on early daily test failure [TMZ-996]

### DIFF
--- a/.github/workflows/daily-test-matrix.yml
+++ b/.github/workflows/daily-test-matrix.yml
@@ -444,6 +444,20 @@ jobs:
             echo "targeted-tests=[]" >> $GITHUB_OUTPUT
           fi
 
+  notify-on-early-failure:
+    name: Notify on Early Failure
+    needs: calculate-test-matrix
+    runs-on: ubuntu-22.04
+    if: always() && needs.calculate-test-matrix.result != 'success'
+    steps:
+      - name: Send Slack notification on early failure
+        continue-on-error: true
+        uses: ./.github/actions/theme-slack-notification-daily-tests
+        with:
+          CLOUD_SLACK_BOT_TOKEN: ${{ secrets.CLOUD_SLACK_BOT_TOKEN }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_CHANNEL: '#tmz-alerts'
+
   trigger-targeted-tests:
     name: Trigger Targeted Tests
     needs: [calculate-test-matrix]


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add Slack notification system for early failures in the daily test workflow to improve visibility of critical issues.
Main changes:
- Implemented new "notify-on-early-failure" job that triggers when the test matrix calculation fails
- Configured Slack notifications to send alerts to #tmz-alerts channel with workflow details
- Added error handling with continue-on-error to prevent notification failures from affecting workflow

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
