### PR TITLE
Internal: Reduce flakiness of daily test for hello theme [ED-22821]

### DIFF
--- a/modules/admin-home/rest/admin-config.php
+++ b/modules/admin-home/rest/admin-config.php
@@ -86,6 +86,7 @@ class Admin_Config extends Rest_Base {
 				'post' => $page_id,
 				'action' => 'elementor',
 				'active-tab' => $active_tab,
+				'active-document' => $active_kit_id,
 			],
 			admin_url( 'post.php' )
 		);

--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -34,47 +34,47 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 		const quickLinksTests = [
 			{
 				linkText: 'Site Name',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity.*active-document=\d+/,
 				expectedPageSection: '.elementor-control-section_settings-site-identity',
 			},
 			{
 				linkText: 'Site Logo',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity.*active-document=\d+/,
 				expectedPageSection: '.elementor-control-section_settings-site-identity',
 			},
 			{
 				linkText: 'Site Favicon',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity.*active-document=\d+/,
 				expectedPageSection: '.elementor-control-section_settings-site-identity',
 			},
 			{
 				linkText: 'Site Colors',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors/,
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors.*active-document=\d+/,
 				expectedPageSection: '.elementor-control-section_global_colors',
 			},
 			{
 				linkText: 'Site Fonts',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography/,
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography.*active-document=\d+/,
 				expectedPageSection: '.elementor-control-section_text_style',
 			},
 		];
 
 		for ( const linkTest of quickLinksTests ) {
-			await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
-			const linkElement = page.locator( `h6:has-text("${ linkTest.linkText }") a` );
-			await expect( linkElement ).toBeVisible();
+			await test.step( linkTest.linkText, async () => {
+				await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
+				const linkElement = page.locator( `h6:has-text("${ linkTest.linkText }") a` );
+				await expect( linkElement ).toBeVisible();
 
-			await Promise.all( [
-				page.waitForURL( linkTest.expectedUrlPattern ),
-				linkElement.click(),
-			] );
+				await Promise.all( [
+					page.waitForURL( linkTest.expectedUrlPattern ),
+					linkElement.click(),
+				] );
 
-			expect( page.url() ).toMatch( linkTest.expectedUrlPattern );
-			// eslint-disable-next-line no-console
-			console.log( `Navigated to ${ linkTest.linkText } page` );
-			await page.waitForSelector( '#elementor-kit-panel' );
-			const location = page.locator( linkTest.expectedPageSection );
-			await expect( location ).toBeVisible();
+				expect( page.url() ).toMatch( linkTest.expectedUrlPattern );
+				await page.waitForSelector( '#elementor-kit-panel' );
+				const location = page.locator( linkTest.expectedPageSection );
+				await expect( location ).toBeVisible();
+			} );
 		}
 	} );
 } );

--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -71,8 +71,8 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 
 			expect( page.url() ).toMatch( linkTest.expectedUrlPattern );
 
-			await page.waitForLoadState( 'networkidle' );
-			await page.waitForSelector( '#elementor-kit-panel' );
+			await page.waitForSelector( '.elementor-panel-loading', { state: 'detached' } );
+			await page.waitForSelector( '#elementor-loading', { state: 'hidden' } );
 			const location = page.locator( linkTest.expectedPageSection );
 			await expect( location ).toBeVisible();
 		} );

--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -30,36 +30,36 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 		}
 	} );
 
-	const quickLinksTests = [
-		{
-			linkText: 'Site Name',
-			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-			expectedPageSection: '.elementor-control-section_settings-site-identity',
-		},
-		{
-			linkText: 'Site Logo',
-			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-			expectedPageSection: '.elementor-control-section_settings-site-identity',
-		},
-		{
-			linkText: 'Site Favicon',
-			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-			expectedPageSection: '.elementor-control-section_settings-site-identity',
-		},
-		{
-			linkText: 'Site Colors',
-			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors/,
-			expectedPageSection: '.elementor-control-section_global_colors',
-		},
-		{
-			linkText: 'Site Fonts',
-			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography/,
-			expectedPageSection: '.elementor-control-section_text_style',
-		},
-	];
+	test( 'should navigate to correct pages from Quick Links', async ( { page } ) => {
+		const quickLinksTests = [
+			{
+				linkText: 'Site Name',
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedPageSection: '.elementor-control-section_settings-site-identity',
+			},
+			{
+				linkText: 'Site Logo',
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedPageSection: '.elementor-control-section_settings-site-identity',
+			},
+			{
+				linkText: 'Site Favicon',
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+				expectedPageSection: '.elementor-control-section_settings-site-identity',
+			},
+			{
+				linkText: 'Site Colors',
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors/,
+				expectedPageSection: '.elementor-control-section_global_colors',
+			},
+			{
+				linkText: 'Site Fonts',
+				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography/,
+				expectedPageSection: '.elementor-control-section_text_style',
+			},
+		];
 
-	for ( const linkTest of quickLinksTests ) {
-		test( `should navigate to correct pages from Quick Links: ${ linkTest.linkText }`, async ( { page } ) => {
+		for ( const linkTest of quickLinksTests ) {
 			await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
 			const linkElement = page.locator( `h6:has-text("${ linkTest.linkText }") a` );
 			await expect( linkElement ).toBeVisible();
@@ -70,11 +70,11 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 			] );
 
 			expect( page.url() ).toMatch( linkTest.expectedUrlPattern );
-
-			await page.waitForSelector( '.elementor-panel-loading', { state: 'detached' } );
-			await page.waitForSelector( '#elementor-loading', { state: 'hidden' } );
+			// eslint-disable-next-line no-console
+			console.log( `Navigated to ${ linkTest.linkText } page` );
+			await page.waitForSelector( '#elementor-kit-panel' );
 			const location = page.locator( linkTest.expectedPageSection );
 			await expect( location ).toBeVisible();
-		} );
-	}
+		}
+	} );
 } );

--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -30,35 +30,36 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 		}
 	} );
 
-	test( 'should navigate to correct pages from Quick Links', async ( { page } ) => {
-		const quickLinksTests = [
-			{
-				linkText: 'Site Name',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-				expectedPageSection: '.elementor-control-section_settings-site-identity',
-			},
-			{
-				linkText: 'Site Logo',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-				expectedPageSection: '.elementor-control-section_settings-site-identity',
-			},
-			{
-				linkText: 'Site Favicon',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
-				expectedPageSection: '.elementor-control-section_settings-site-identity',
-			},
-			{
-				linkText: 'Site Colors',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors/,
-				expectedPageSection: '.elementor-control-section_global_colors',
-			},
-			{
-				linkText: 'Site Fonts',
-				expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography/,
-				expectedPageSection: '.elementor-control-section_text_style',
-			},
-		];
-		for ( const linkTest of quickLinksTests ) {
+	const quickLinksTests = [
+		{
+			linkText: 'Site Name',
+			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+			expectedPageSection: '.elementor-control-section_settings-site-identity',
+		},
+		{
+			linkText: 'Site Logo',
+			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+			expectedPageSection: '.elementor-control-section_settings-site-identity',
+		},
+		{
+			linkText: 'Site Favicon',
+			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=settings-site-identity/,
+			expectedPageSection: '.elementor-control-section_settings-site-identity',
+		},
+		{
+			linkText: 'Site Colors',
+			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-colors/,
+			expectedPageSection: '.elementor-control-section_global_colors',
+		},
+		{
+			linkText: 'Site Fonts',
+			expectedUrlPattern: /post\.php\?post=\d+&action=elementor.*active-tab=global-typography/,
+			expectedPageSection: '.elementor-control-section_text_style',
+		},
+	];
+
+	for ( const linkTest of quickLinksTests ) {
+		test( `should navigate to correct pages from Quick Links: ${ linkTest.linkText }`, async ( { page } ) => {
 			await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
 			const linkElement = page.locator( `h6:has-text("${ linkTest.linkText }") a` );
 			await expect( linkElement ).toBeVisible();
@@ -70,9 +71,10 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 
 			expect( page.url() ).toMatch( linkTest.expectedUrlPattern );
 
+			await page.waitForLoadState( 'networkidle' );
 			await page.waitForSelector( '#elementor-kit-panel' );
 			const location = page.locator( linkTest.expectedPageSection );
 			await expect( location ).toBeVisible();
-		}
-	} );
+		} );
+	}
 } );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix flaky Playwright tests for Hello Theme admin navigation by adding active-document parameter to URL generation and updating test URL patterns.

Main changes:
- Added active-document query parameter with active_kit_id to admin config URL builder for proper editor state initialization
- Updated test URL regex patterns to include active-document parameter validation for all Quick Links navigation tests
- Wrapped each Quick Links test in test.step for better test isolation and more granular failure reporting

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
