### PR TITLE
Fix: Inconsistent padding between date picker and time picker in Hello theme [TMZ-1036]

### DIFF
--- a/dev/scss/reset/_forms.scss
+++ b/dev/scss/reset/_forms.scss
@@ -29,6 +29,7 @@ textarea {
 
 input[type="text"],
 input[type="date"],
+input[type="time"],
 input[type="email"],
 input[type="number"],
 input[type="password"],


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Date picker and time picker had inconsistent padding in Hello theme. Adding `input[type="time"]` to the shared form reset styles ensures uniform styling across both picker types.

## 2. What Changed (Where)

`dev/scss/reset/_forms.scss`: Added `input[type="time"]` selector to the grouped input styling rule alongside existing date/text/email/number inputs.

## 3. How It Works

The time input selector now inherits the same `line-height: 1.5` and `margin: 0` reset styles as the date picker, eliminating visual discrepancies.

## 4. Risks

None. Selector addition to reset styles is safe and isolated.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
