### PR TITLE
Internal: Skip test in GA version [TMZ-1040]

### DIFF
--- a/.github/workflows/playwright-with-specific-elementor-version.yml
+++ b/.github/workflows/playwright-with-specific-elementor-version.yml
@@ -237,8 +237,11 @@ jobs:
           export TEST_TITLE="Hello Theme Core Test - HT ${HELLO_THEME_VERSION} + EL ${ELEMENTOR_VERSION}"
           export DAILY_MATRIX_WORKFLOW=true
           echo "Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
-          # Only run Hello Theme tests, not Elementor or other plugin tests
-          npm run test:playwright -- tests/playwright/tests/
+
+          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links"'
+          echo "Skipping known failing test: 'should navigate to correct pages from Quick Links'"
+
+          eval npm run test:playwright -- tests/playwright/tests/ $GREP_INVERT_FLAG
 
       - name: Skip tests - version incompatible
         if: steps.extract-version-tests.outputs.tests-available != 'true'


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Skipping a known failing test in GA version to unblock CI runs. Specific test "should navigate to correct pages from Quick Links" fails with certain Elementor/Hello Theme combinations.

## 2. What Changed (Where)

`.github/workflows/playwright-with-specific-elementor-version.yml`: Modified test execution to use `--grep-invert` flag excluding the problematic test case.

## 3. How It Works

Replaces hardcoded npm command with dynamic invocation that passes grep invert flag, filtering out the failing test while running remaining Hello Theme test suite.

## 4. Risks

Temporary workaround masks underlying test flakiness—underlying incompatibility should be tracked and fixed rather than indefinitely skipped.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
