### PR TITLE
Internal: Replace hardcoded media query with SASS variable [TMZ-1043]

### DIFF
--- a/dev/scss/theme/_navigation.scss
+++ b/dev/scss/theme/_navigation.scss
@@ -262,7 +262,7 @@ footer {
 	}
 }
 
-@media (min-width: variables.$screen-xs) and (max-width: 767px) {
+@media (min-width: variables.$screen-xs) and (max-width: variables.$screen-sm - variables.$screen-diff) {
 	.site-header.menu-dropdown-mobile:not(.menu-layout-dropdown) {
 
         .site-navigation {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Replace hardcoded breakpoint value (767px) with SASS variable for maintainability and consistency across the theme.

## 2. What Changed (Where)

- `dev/scss/theme/_navigation.scss`: Media query breakpoint changed from `767px` to `variables.$screen-sm - variables.$screen-diff` expression.

## 3. How It Works

The hardcoded `767px` is now computed dynamically using SASS variables, ensuring breakpoint calculations stay synchronized with the theme's variable definitions. Functionality remains identical.

## 4. Risks

None. Pure refactor with no behavioral change—assumes variable values produce equivalent computed breakpoint.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
