### PR TITLE
docs: fix 'elemntor' typo in readme.txt Contributors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Hello Elementor ===
 
-Contributors: elemntor, KingYes, ariel.k, bainternet
+Contributors: elementor, KingYes, ariel.k, bainternet
 Requires at least: 6.0
 Tested up to: 7.0
 Stable tag: 3.4.9


### PR DESCRIPTION
Tiny typo fix in the Contributors line of readme.txt.