### PR TITLE
Internal: Skip pro banner test inside Hello Theme [TMZ-1042]

### DIFF
--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -6,7 +6,8 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 		await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
 	} );
 
-	test( 'should display Welcome to Hello Theme message and take screenshot', async ( { page } ) => {
+	// Skipped, because this banner is disabled from the Elementor plugin.
+	test.skip( 'should display Welcome to Hello Theme message and take screenshot', async ( { page } ) => {
 		const welcomeSection = page.locator( 'text=Go Pro, Go Limitless' ).locator( '..' ).locator( '..' );
 		await expect.soft( welcomeSection ).toHaveScreenshot( 'welcome-section.png' );
 	} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

The pro banner test in Hello Theme admin is disabled at the plugin level, making the test fail. Skipping it prevents CI breakage while maintaining the test suite.

## 2. What Changed (Where)

- `hello-theme-admin-home.test.ts`: Added `test.skip()` wrapper and explanatory comment to the "Welcome to Hello Theme" screenshot test (lines 9-10).

## 3. How It Works

The test declaration now uses Playwright's `test.skip()` method, which prevents execution while keeping the test visible in reports for future reference.

## 4. Risks

None — this is a defensive measure for an already-failing test that blocks CI. The skip is temporary and documented.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
