### PR TITLE
Internal: Skip pro banner tests in workflows [TMZ-1042]

### DIFF
--- a/.github/workflows/playwright-with-specific-elementor-version.yml
+++ b/.github/workflows/playwright-with-specific-elementor-version.yml
@@ -238,8 +238,8 @@ jobs:
           export DAILY_MATRIX_WORKFLOW=true
           echo "Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
 
-          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links"'
-          echo "Skipping known failing test: 'should navigate to correct pages from Quick Links'"
+          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links" --grep-invert="should display Welcome to Hello Theme message and take screenshot"'
+          echo "Skipping known failing tests: 'should navigate to correct pages from Quick Links', 'should display Welcome to Hello Theme message and take screenshot'"
 
           eval npm run test:playwright -- tests/playwright/tests/ $GREP_INVERT_FLAG
 

--- a/.github/workflows/playwright-with-specific-hello-plus-version.yml
+++ b/.github/workflows/playwright-with-specific-hello-plus-version.yml
@@ -255,8 +255,8 @@ jobs:
           export DAILY_MATRIX_WORKFLOW=true
           echo "Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
 
-          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links"'
-          echo "Skipping known failing test: 'should navigate to correct pages from Quick Links'"
+          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links" --grep-invert="should display Welcome to Hello Theme message and take screenshot"'
+          echo "Skipping known failing tests: 'should navigate to correct pages from Quick Links', 'should display Welcome to Hello Theme message and take screenshot'"
 
           eval npm run test:playwright -- tests/playwright/tests/ $GREP_INVERT_FLAG
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Pro banner tests are failing in daily CI workflows (TMZ-1042). Adding them to the skip list prevents workflow failures while they're being addressed separately.

## 2. What Changed (Where)

- `.github/workflows/playwright-with-specific-elementor-version.yml`: Extended grep-invert filter to skip pro banner test in addition to Quick Links test
- `.github/workflows/playwright-with-specific-hello-plus-version.yml`: Same grep-invert filter expansion across both daily matrix workflows

## 3. How It Works

Grep-invert flags exclude specific test cases from execution. Updated filter now blocks two tests: "should navigate to correct pages from Quick Links" (existing) and "should display Welcome to Hello Theme message and take screenshot" (new pro banner test).

## 4. Risks

None—this is a surgical test exclusion. Tests remain in codebase and can be re-enabled once fixed.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
