### PR TITLE
Internal: Unskip test welcome test [TMZ-1042]

### DIFF
--- a/.github/workflows/playwright-with-specific-elementor-version.yml
+++ b/.github/workflows/playwright-with-specific-elementor-version.yml
@@ -238,8 +238,8 @@ jobs:
           export DAILY_MATRIX_WORKFLOW=true
           echo "Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
 
-          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links" --grep-invert="should display Welcome to Hello Theme message and take screenshot"'
-          echo "Skipping known failing tests: 'should navigate to correct pages from Quick Links', 'should display Welcome to Hello Theme message and take screenshot'"
+          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links"'
+          echo "Skipping known failing test: 'should navigate to correct pages from Quick Links'"
 
           eval npm run test:playwright -- tests/playwright/tests/ $GREP_INVERT_FLAG
 

--- a/.github/workflows/playwright-with-specific-hello-plus-version.yml
+++ b/.github/workflows/playwright-with-specific-hello-plus-version.yml
@@ -255,8 +255,8 @@ jobs:
           export DAILY_MATRIX_WORKFLOW=true
           echo "Running tests from: ${{ steps.extract-version-tests.outputs.test-source-type }}"
 
-          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links" --grep-invert="should display Welcome to Hello Theme message and take screenshot"'
-          echo "Skipping known failing tests: 'should navigate to correct pages from Quick Links', 'should display Welcome to Hello Theme message and take screenshot'"
+          GREP_INVERT_FLAG='--grep-invert="should navigate to correct pages from Quick Links"'
+          echo "Skipping known failing test: 'should navigate to correct pages from Quick Links'"
 
           eval npm run test:playwright -- tests/playwright/tests/ $GREP_INVERT_FLAG
 

--- a/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
+++ b/tests/playwright/tests/admin/hello-theme-admin-home.test.ts
@@ -6,8 +6,7 @@ test.describe( 'Hello Theme Admin Home Page', () => {
 		await page.goto( '/wp-admin/admin.php?page=hello-elementor' );
 	} );
 
-	// Skipped, because this banner is disabled from the Elementor plugin.
-	test.skip( 'should display Welcome to Hello Theme message and take screenshot', async ( { page } ) => {
+	test( 'should display Welcome to Hello Theme message and take screenshot', async ( { page } ) => {
 		const welcomeSection = page.locator( 'text=Go Pro, Go Limitless' ).locator( '..' ).locator( '..' );
 		await expect.soft( welcomeSection ).toHaveScreenshot( 'welcome-section.png' );
 	} );


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Re-enabling the "Welcome to Hello Theme" admin test (TMZ-1042) which was previously skipped due to Elementor plugin disabling the banner. Test infrastructure updated to skip only the unrelated Quick Links test that still fails.

## 2. What Changed (Where)

- `hello-theme-admin-home.test.ts`: Removed `test.skip()` wrapper and comment from Welcome message test, converting it back to active test
- Two CI workflows: Reduced `GREP_INVERT_FLAG` to skip only Quick Links test (removed Welcome test from exclusion list)

## 3. How It Works

The Welcome banner test now runs again in CI. Grep invert flag remains to exclude the Quick Links test which has persistent failures—creating asymmetry between the two workflows where Welcome is re-enabled but Quick Links continues skipped via CLI invocation rather than `test.skip()`.

## 4. Risks

Test may fail if Elementor plugin still disables the banner or if the "Go Pro, Go Limitless" locator changed. Inconsistency between workflows (one skips at test definition, other at CLI) could cause maintenance confusion.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
