### PR TITLE
Internal: Fix filing PHPUnit tests [TMZ-1050]

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wordpress_versions: ['nightly', 'latest', '6.6', '6.5']
+        wordpress_versions: ['nightly', 'latest', '6.9', '6.8']
         php_versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
     name: PHPUnit - WordPress ${{ matrix.wordpress_versions }} - PHP version ${{ matrix.php_versions }}
     env:


### PR DESCRIPTION
**The issue:**

The CI failure is caused by Elementor 4.x requiring WordPress 6.8+ while hello-theme still tests WordPress 6.5/6.6.

Elementor never loads on those WordPress versions, so `Elementor_Test_Base::setUp()` fails.

**The solution:**

Updating the WordPress version matrix in `.github/workflows/phpunit.yml` should fix the issue.





<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

PHPUnit test matrix was testing against outdated WordPress versions (6.5, 6.6). This PR updates to more recent versions to ensure Hello theme compatibility with current WordPress releases (TMZ-1050).

## 2. What Changed (Where)

`.github/workflows/phpunit.yml`: WordPress test matrix versions updated from `['nightly', 'latest', '6.6', '6.5']` to `['nightly', 'latest', '6.9', '6.8']`.

## 3. How It Works

CI workflow runs PHPUnit tests against the new matrix combinations. Each WordPress version paired with five PHP versions (7.4–8.3) for comprehensive compatibility coverage.

## 4. Risks

None. Bumping to newer WordPress versions increases test coverage relevance without breaking changes to test infrastructure.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
