### PR TITLE
Internal: Update `ecmaVersion` in ESLint config from 2017 to 2023 [TMZ-1052]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
 		__: true,
 	},
 	parserOptions: {
-		ecmaVersion: 2017,
+		ecmaVersion: 2023,
 		sourceType: 'module',
 		ecmaFeatures: {
 			jsx: true,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Updating ESLint parser target from ES2017 to ES2023 to support modern JavaScript syntax and align with current ecosystem standards (TMZ-1052).

## 2. What Changed (Where)

`.eslintrc.js`: `parserOptions.ecmaVersion` bumped from 2017 to 2023.

## 3. How It Works

ESLint parser now recognizes ES2023 syntax (e.g., top-level await, static class initialization blocks, Array.prototype.findLast). No configuration restructuring—straightforward version field update.

## 4. Risks

Minimal. If codebase contains unsupported syntax for older targets, linting will now catch it earlier. Verify no intentional ES5-only constraints exist in the project.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
