### PR TITLE
Fix: Wrapping div has height despite no content shown. [ED-24996]

### DIFF
--- a/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
+++ b/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
@@ -8,12 +8,18 @@ const App = () => {
 	return (
 		<ThemeProvider colorScheme="auto">
 			<AdminProvider>
-				<Box sx={{ pt: 2, pr: 2, pb: 1 }}>
-					<Welcome
-						sx={{ width: '100%', px: 4, py: 3, position: 'relative' }}
-						dismissable
-					/>
-				</Box>
+				<Welcome
+					sx={{
+						mt: 2,
+						mr: 2,
+						mb: 1,
+						width: '100%',
+						px: 4,
+						py: 3,
+						position: 'relative',
+					}}
+					dismissable
+				/>
 			</AdminProvider>
 		</ThemeProvider>
 	);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Wrapping `Box` component was causing unwanted height on the banner container. Moved spacing logic directly to `Welcome` component via `sx` prop to eliminate the outer wrapper.

## 2. What Changed (Where)

- **hello-elementor-conversion-banner.js**: Removed `Box` wrapper; consolidated `pt/pr/pb` spacing into `mt/mr/mb` on `Welcome` component with `width: 100%` applied directly.

## 3. How It Works

`Welcome` now manages its own spacing through margin and padding props instead of relying on parent `Box` for layout. No structural change—purely shifting responsibility for spacing down one level.

## 4. Risks

None. DOM structure simplified; behavior identical since `Welcome` applies the same spacing values.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
