### PR TITLE
Internal: Add Upgrade to Pro button in Hello Theme top bar [TMZ-1067]

### DIFF
--- a/modules/admin-home/assets/js/components/top-bar/top-bar-content.js
+++ b/modules/admin-home/assets/js/components/top-bar/top-bar-content.js
@@ -1,6 +1,7 @@
 import Stack from '@elementor/ui/Stack';
 import DynamicIcon from '../dynamic-icon';
 import Typography from '@elementor/ui/Typography';
+import { UpgradeButton } from './upgrade-button';
 import { __ } from '@wordpress/i18n';
 
 export const TopBarContent = ({ sx = {}, iconSize = 'medium' }) => {
@@ -23,6 +24,7 @@ export const TopBarContent = ({ sx = {}, iconSize = 'medium' }) => {
 					{__('Hello', 'hello-elementor')}
 				</Typography>
 			</Stack>
+			<UpgradeButton />
 		</Stack>
 	);
 };

--- a/modules/admin-home/assets/js/components/top-bar/upgrade-button.js
+++ b/modules/admin-home/assets/js/components/top-bar/upgrade-button.js
@@ -17,6 +17,7 @@ export const UpgradeButton = () => {
 			color="promotion"
 			size="small"
 			startIcon={<CrownIcon />}
+			sx={{ '&:hover': { backgroundColor: 'transparent' } }}
 		>
 			{__('Upgrade Now', 'hello-elementor')}
 		</Button>

--- a/modules/admin-home/assets/js/components/top-bar/upgrade-button.js
+++ b/modules/admin-home/assets/js/components/top-bar/upgrade-button.js
@@ -1,0 +1,24 @@
+import Button from '@elementor/ui/Button';
+import CrownIcon from '@elementor/icons/CrownIcon';
+import { __ } from '@wordpress/i18n';
+
+export const UpgradeButton = () => {
+	const upgradeUrl = window.ehpTopBarConfig?.upgradeUrl;
+
+	if (!upgradeUrl) {
+		return null;
+	}
+
+	return (
+		<Button
+			href={upgradeUrl}
+			target="_blank"
+			rel="noopener noreferrer"
+			color="promotion"
+			size="small"
+			startIcon={<CrownIcon />}
+		>
+			{__('Upgrade Now', 'hello-elementor')}
+		</Button>
+	);
+};

--- a/modules/admin-home/assets/js/hello-elementor-topbar.js
+++ b/modules/admin-home/assets/js/hello-elementor-topbar.js
@@ -1,8 +1,13 @@
 import { createRoot } from 'react-dom/client';
+import { ThemeProvider } from '@elementor/ui/styles';
 import { TopBar } from './components/top-bar/top-bar';
 
 const App = () => {
-	return <TopBar />;
+	return (
+		<ThemeProvider colorScheme="auto">
+			<TopBar />
+		</ThemeProvider>
+	);
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/modules/admin-home/components/admin-top-bar.php
+++ b/modules/admin-home/components/admin-top-bar.php
@@ -11,6 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Admin_Top_Bar {
 
+	const CONFIG_OBJECT_NAME = 'ehpTopBarConfig';
+	const UPGRADE_PRO_URL = 'https://go.elementor.com/hello-upgrade-epro/';
+
 	private function render_admin_top_bar() {
 		?>
 		<div id="ehe-admin-top-bar-root" style="height: 50px">
@@ -30,6 +33,16 @@ class Admin_Top_Bar {
 		);
 
 		$script->enqueue();
+
+		if ( Utils::has_pro() ) {
+			return;
+		}
+
+		wp_localize_script(
+			'hello-elementor-topbar',
+			self::CONFIG_OBJECT_NAME,
+			[ 'upgradeUrl' => self::UPGRADE_PRO_URL ]
+		);
 	}
 
 	public function __construct() {

--- a/modules/admin-home/components/settings-controller.php
+++ b/modules/admin-home/components/settings-controller.php
@@ -148,13 +148,7 @@ class Settings_Controller {
 		);
 	}
 
-	/**
-	 * The Hello menu item redirects to this page, so its submenu entry is redundant.
-	 *
-	 * Removing it during `admin_menu` would also make the page unreachable, because
-	 * WordPress resolves a plugin page's hook by looking the slug up in the submenu
-	 * globals. `admin_head` runs after that lookup and before the menu is rendered.
-	 */
+	// Runs on `admin_head`, not `admin_menu`: removing the submenu earlier breaks the page hook resolution and makes the page unreachable.
 	public function hide_settings_submenu_item(): void {
 		remove_submenu_page( $this->parent_slug, self::SETTINGS_PAGE_SLUG );
 	}

--- a/modules/admin-home/components/settings-controller.php
+++ b/modules/admin-home/components/settings-controller.php
@@ -22,6 +22,8 @@ class Settings_Controller {
 		'HELLO_THEME'          => '_hello_theme',
 	];
 
+	private string $parent_slug = '';
+
 	public static function get_settings_mapping(): array {
 		return array_map(
 			function ( $key ) {
@@ -134,6 +136,8 @@ class Settings_Controller {
 	}
 
 	public function register_settings_page( $parent_slug ): void {
+		$this->parent_slug = $parent_slug;
+
 		add_submenu_page(
 			$parent_slug,
 			__( 'Settings', 'hello-elementor' ),
@@ -142,10 +146,17 @@ class Settings_Controller {
 			self::SETTINGS_PAGE_SLUG,
 			[ $this, 'render_settings_page' ]
 		);
+	}
 
-		// The Hello menu item already redirects here, so the entry is hidden while the page
-		// stays registered to keep the existing settings URL working.
-		remove_submenu_page( $parent_slug, self::SETTINGS_PAGE_SLUG );
+	/**
+	 * The Hello menu item redirects to this page, so its submenu entry is redundant.
+	 *
+	 * Removing it during `admin_menu` would also make the page unreachable, because
+	 * WordPress resolves a plugin page's hook by looking the slug up in the submenu
+	 * globals. `admin_head` runs after that lookup and before the menu is rendered.
+	 */
+	public function hide_settings_submenu_item(): void {
+		remove_submenu_page( $this->parent_slug, self::SETTINGS_PAGE_SLUG );
 	}
 
 	public function render_settings_page(): void {
@@ -154,6 +165,7 @@ class Settings_Controller {
 
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_hello_plus_settings_scripts' ] );
+		add_action( 'admin_head', [ $this, 'hide_settings_submenu_item' ] );
 		add_action( 'hello-plus-theme/admin-menu', [ $this, 'register_settings_page' ], 10, 1 );
 	}
 }

--- a/modules/admin-home/components/settings-controller.php
+++ b/modules/admin-home/components/settings-controller.php
@@ -142,6 +142,10 @@ class Settings_Controller {
 			self::SETTINGS_PAGE_SLUG,
 			[ $this, 'render_settings_page' ]
 		);
+
+		// The Hello menu item already redirects here, so the entry is hidden while the page
+		// stays registered to keep the existing settings URL working.
+		remove_submenu_page( $parent_slug, self::SETTINGS_PAGE_SLUG );
 	}
 
 	public function render_settings_page(): void {

--- a/tests/playwright/tests/theme-settings.test.ts
+++ b/tests/playwright/tests/theme-settings.test.ts
@@ -25,7 +25,7 @@ test.describe('Admin Menu', () => {
 		await expect(page).toHaveURL(/page=hello-elementor-settings/);
 	});
 
-	test('does not show Home submenu', async ({
+	test('does not show submenu items', async ({
 		page,
 		apiRequests,
 	}, testInfo) => {
@@ -36,8 +36,6 @@ test.describe('Admin Menu', () => {
 		const helloMenu = page.locator('#toplevel_page_hello-elementor');
 		await helloMenu.hover();
 
-		await expect(
-			page.locator('#toplevel_page_hello-elementor .wp-submenu'),
-		).not.toContainText('Home');
+		await expect(helloMenu.locator('.wp-submenu li')).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
## Summary

Removing the Hello Theme Home screen also removed the Upgrade to Pro banner, leaving no upgrade CTA in the admin. This adds one to the Hello settings top bar, reusing the same `go.elementor.com/hello-upgrade-epro` link the old banner used.

- `Admin_Top_Bar` localizes the upgrade URL **only when Elementor Pro is inactive**, so the Pro check lives in PHP and the React side just renders whatever config it is given.
- New `UpgradeButton` renders `Upgrade Now` with `CrownIcon` and `color="promotion"`, matching how Core styles its own admin top bar upgrade CTA.
- The top bar root is now wrapped in the Elementor UI `ThemeProvider`, matching the settings and conversion banner entries. Without it the tree falls back to the default MUI theme, which has no `promotion` palette entry, so the button did not paint.

## Jira

[TMZ-1067](https://elementor.atlassian.net/browse/TMZ-1067)

## Test plan

- [ ] With Elementor Pro **deactivated**, open `admin.php?page=hello-elementor-settings` and confirm the crown + `Upgrade Now` button appears at the right of the top bar
- [ ] Confirm it links to `https://go.elementor.com/hello-upgrade-epro/` and opens in a new tab
- [ ] With Elementor Pro **activated**, confirm the button is absent and `window.ehpTopBarConfig` is not defined
- [ ] Confirm the existing `Hello` branding and top bar layout are unchanged in both light and dark admin color schemes

Made with [Cursor](https://cursor.com)

[TMZ-1067]: https://elementor.atlassian.net/browse/TMZ-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding "Upgrade to Pro" button to Hello Theme admin top bar for users without Elementor Pro, reducing friction to upgrade path. Ticket: TMZ-1067.

## 2. What Changed (Where)

- **admin-top-bar.php**: Added config constants and conditional script localization with upgrade URL (only for non-Pro users)
- **settings-controller.php**: Stored parent slug, added hook to hide Settings submenu item on `admin_head`
- **top-bar-content.js & upgrade-button.js**: New UpgradeButton component consuming config from window object
- **hello-elementor-topbar.js**: Wrapped App in ThemeProvider for styling
- **theme-settings.test.ts**: Updated test to verify zero submenu items instead of checking Home text

## 3. How It Works

TopBar mounts on `DOMContentLoaded` → renders UpgradeButton if `window.ehpTopBarConfig.upgradeUrl` exists → PHP conditionally localizes script data only for non-Pro users via `Utils::has_pro()` check. Settings submenu hidden via separate `admin_head` action hook (avoids page hook resolution issues from `admin_menu`).

## 4. Risks

Config object accessed directly from window without type safety; gracefully handles missing data but depends on script localization executing. ThemeProvider wrapping adds dependency on Elementor UI theme consistency.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
