### PR TITLE
Internal: Add WP Playground PR preview and build artifact comment [TMZ-1068]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,12 @@ jobs:
   build_plugin:
     name: Build theme
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    outputs:
+      artifact_name: hello-elementor
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,12 +33,21 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Set environment variables
+        run: |
+          DATE_VERSION=$(date '+%Y%m%d.%H%M')
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          THEME_ZIP_FILENAME="hello-elementor.${PACKAGE_VERSION}.zip"
+
+          echo "DATE_VERSION=$DATE_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "THEME_ZIP_FILENAME=$THEME_ZIP_FILENAME" >> "$GITHUB_ENV"
       - name: "Debug info: show tooling versions"
         continue-on-error: true
         run: |
           set +e
           echo "Start debug Info"
-          echo "Date: ${{ steps.date.outputs.date }}"
+          echo "Date: ${{ env.DATE_VERSION }}"
           echo "PHP Version: $(php -v)"
           echo "Composer Version: $(composer --version)"
           echo "Node Version: $(node --version)"
@@ -54,8 +69,63 @@ jobs:
       - name: Build
         run: npm run zip
       - name: Upload zip file to GitHub actions artifact
+        id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
           name: hello-elementor
           path: hello-elementor.*.zip
+          if-no-files-found: error
           retention-days: 7
+      - name: Find existing comment on PR (Elementor repo)
+        if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.repo.full_name, 'elementor/')
+        uses: peter-evans/find-comment@v4
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Hello Elementor Build'
+      - name: Comment build info on PR (Elementor repo)
+        if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.repo.full_name, 'elementor/')
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## Hello Elementor Build
+            Last updated at: ${{ env.DATE_VERSION }}
+            Version: ${{ env.PACKAGE_VERSION }}
+
+            ✅ Hello Elementor build is ready for download.
+
+            You can download the latest build from the link below:
+
+            🔗 [${{ env.THEME_ZIP_FILENAME }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifact.outputs.artifact-id }})
+
+            The build is available for 7 days.
+
+          edit-mode: replace
+      - name: Print artifact info for fork PR
+        if: github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.repo.full_name, 'elementor/')
+        run: |
+          echo "Artifact info:"
+          echo "  Name: hello-elementor"
+          echo "  Path: ${{ env.THEME_ZIP_FILENAME }}"
+          echo "  Size: $(du -sh "${{ env.THEME_ZIP_FILENAME }}" | cut -f1)"
+          echo "  URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artifact.outputs.artifact-id }}"
+
+  playground-preview:
+    needs: [build_plugin]
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.build_plugin.result == 'success' &&
+      startsWith(github.repository, 'elementor/')
+    permissions:
+      contents: read
+      actions: read
+      deployments: write
+    uses: ./.github/workflows/playground-preview.yml
+    with:
+      artifact_name: ${{ needs.build_plugin.outputs.artifact_name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      head_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,109 @@
+name: Playground PR Preview
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Theme build artifact name from the PR build job
+        required: true
+        type: string
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      head_sha:
+        description: PR head commit SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  deployments: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download theme artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: build-artifact
+
+      - name: Repack build artifact for Playground
+        run: |
+          THEME_ZIP=$(find build-artifact -maxdepth 1 -name 'hello-elementor.*.zip' -type f | head -1)
+          if [ -z "$THEME_ZIP" ]; then
+            echo "Expected hello-elementor.<version>.zip not found in build artifact"
+            ls -la build-artifact/
+            exit 1
+          fi
+          rm -rf theme-root theme-staging
+          mkdir -p theme-staging theme-root
+          unzip -q "$THEME_ZIP" -d theme-staging
+          if [ -d theme-staging/hello-elementor ]; then
+            cp -a theme-staging/hello-elementor theme-root/
+          else
+            mkdir -p theme-root/hello-elementor
+            cp -a theme-staging/. theme-root/hello-elementor/
+          fi
+          test -f theme-root/hello-elementor/style.css
+
+      - name: Upload Playground theme artifact
+        id: playground-artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: playground-theme-pr${{ inputs.pr_number }}-${{ inputs.head_sha }}
+          path: theme-root
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Prepare blueprint JSON
+        id: blueprint
+        env:
+          ARTIFACT_NAME: playground-theme-pr${{ inputs.pr_number }}-${{ inputs.head_sha }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+          const artifactName = process.env.ARTIFACT_NAME;
+          const runId = process.env.GITHUB_RUN_ID;
+          const url = `https://nightly.link/${owner}/${repo}/actions/runs/${runId}/${artifactName}.zip`;
+          const template = fs.readFileSync('tests/playwright/blueprints/pr-preview.json', 'utf8');
+          const blueprint = template.replace(/\$THEME_ZIP_URL/g, url);
+          JSON.parse(blueprint);
+          const playgroundUrl = `https://playground.wordpress.net/?blueprint-url=data:application/json,${encodeURIComponent(blueprint)}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `theme-zip-url=${url}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `json<<BLUEPRINT_JSON_EOF\n${blueprint}\nBLUEPRINT_JSON_EOF\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `playground-url=${playgroundUrl}\n`);
+          NODE
+
+      - name: Create PR deployment
+        uses: actions/github-script@v9
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PREVIEW_URL: ${{ steps.blueprint.outputs.playground-url }}
+        with:
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+              environment: 'playground-preview',
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: `WP Playground preview for PR #${process.env.PR_NUMBER}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment_url: process.env.PREVIEW_URL,
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/tests/playwright/blueprints/pr-preview.json
+++ b/tests/playwright/blueprints/pr-preview.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin",
+	"preferredVersions": { "php": "7.4", "wp": "latest" },
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{ "step": "login", "username": "admin", "password": "password" },
+		{
+			"step": "installTheme",
+			"themeData": {
+				"resource": "url",
+				"url": "$THEME_ZIP_URL"
+			}
+		},
+		{ "step": "activateTheme", "themeFolderName": "hello-elementor" }
+	]
+}


### PR DESCRIPTION
## Summary

Brings Elementor Core's PR experience to Hello Theme, adapted for a theme (not a plugin):

- **Theme-only Playground preview** - `tests/playwright/blueprints/pr-preview.json` installs and activates **only** the built `hello-elementor` theme from a nightly.link artifact URL. No Elementor plugin, options, experiments, or other packages are added by the blueprint.
- **Reusable preview workflow** - `.github/workflows/playground-preview.yml` downloads the PR build artifact, validates `hello-elementor.<version>.zip`, repacks a Playground artifact rooted at `hello-elementor/`, generates the `playground.wordpress.net` URL, and creates a transient `playground-preview` deployment on the PR head SHA.
- **Build integration** - `build.yml` runs the `playground-preview` job only for successful PR builds in elementor-owned repos, and now posts a **build-artifact comment** on elementor-owned PRs (with a fork fallback that prints artifact info to the job log), mirroring Core.

## Notes

- Fork PRs skip the deployment link (read-only token) and fall back to logged artifact info.
- No theme runtime code, tests, or docs were changed; no unrelated action/version bumps.

## Test plan

- [ ] Open a same-repo PR and confirm the "Hello Elementor Build" comment appears with a working artifact link.
- [ ] Confirm the `playground-preview` deployment shows up and its URL boots WordPress with only Hello Elementor active (theme active, no Elementor plugin).
- [ ] Open a fork PR and confirm CI stays green with artifact info printed to the log (no failed deployment step).

Ref: TMZ-1068

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Enable WP Playground PR previews and build artifact tracking for Elementor repo PRs. Automates environment setup with timestamped builds and GitHub deployment integration.

## 2. What Changed (Where)

- `.github/workflows/build.yml`: Add job permissions, environment variables (DATE_VERSION, PACKAGE_VERSION), PR comment with artifact link, fork PR artifact info fallback
- `.github/workflows/playground-preview.yml`: New workflow downloads build artifact, repacks for Playground, generates blueprint JSON, creates GitHub deployment
- `tests/playwright/blueprints/pr-preview.json`: Blueprint template for Playground environment with theme installation

## 3. How It Works

Build job exports `artifact_name` output, generates versioned ZIP filename and timestamp. For Elementor repo PRs, posts/updates comment with artifact download link; for forks, prints artifact info to logs. Playground preview workflow downloads artifact, restructures directory layout, generates theme zip URL in blueprint JSON, creates deployment with Playground URL as environment_url. Blueprint auto-logs in, installs theme from URL, activates hello-elementor.

## 4. Risks

- Playground preview only runs on Elementor repo PRs (`startsWith(github.repository, 'elementor/')`), but build job comment condition uses `startsWith(github.event.pull_request.head.repo.full_name, 'elementor/')` — different scopes could diverge
- Artifact retention 7 days vs preview artifact 3 days; if build fails or artifacts expire, deployment link breaks silently
- No validation that `pr-preview.json` blueprint is valid before deployment creation

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
