### PR TITLE
Internal: Update upgrade notice copy and top bar upgrade link [TMZ-1069][TMZ-1067]

### DIFF
--- a/modules/admin-home/components/admin-top-bar.php
+++ b/modules/admin-home/components/admin-top-bar.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Admin_Top_Bar {
 
 	const CONFIG_OBJECT_NAME = 'ehpTopBarConfig';
-	const UPGRADE_PRO_URL = 'https://go.elementor.com/hello-upgrade-epro/';
+	const UPGRADE_PRO_URL = 'https://go.elementor.com/go-pro-hello-theme-upgrade-top-bar/';
 
 	private function render_admin_top_bar() {
 		?>

--- a/modules/admin-home/rest/admin-config.php
+++ b/modules/admin-home/rest/admin-config.php
@@ -76,8 +76,8 @@ class Admin_Config extends Rest_Base {
 
 		if ( $is_elementor_active && ! $has_pro ) {
 			$config['welcome'] = [
-				'title'   => __( 'Go Pro, Go Limitless', 'hello-elementor' ),
-				'text'    => __( 'Unlock the theme builder, popup builder, 100+ widgets and more advanced tools to take your website to the next level.', 'hello-elementor' ),
+				'title'   => __( 'Build more with Elementor Pro', 'hello-elementor' ),
+				'text'    => __( 'Add the theme builder, popup builder, and 100+ advanced widgets to your Elementor editor.', 'hello-elementor' ),
 				'buttons' => [
 					[
 						'linkText' => __( 'Upgrade now', 'hello-elementor' ),

--- a/modules/admin-home/rest/admin-config.php
+++ b/modules/admin-home/rest/admin-config.php
@@ -77,7 +77,7 @@ class Admin_Config extends Rest_Base {
 		if ( $is_elementor_active && ! $has_pro ) {
 			$config['welcome'] = [
 				'title'   => __( 'Build more with Elementor Pro', 'hello-elementor' ),
-				'text'    => __( 'Add the theme builder, popup builder, and 100+ advanced widgets to your Elementor editor.', 'hello-elementor' ),
+				'text'    => __( 'Add the theme builder, popup builder, and 85+ advanced widgets to your Elementor Editor.', 'hello-elementor' ),
 				'buttons' => [
 					[
 						'linkText' => __( 'Upgrade now', 'hello-elementor' ),

--- a/tests/playwright/tests/theme-settings.test.ts
+++ b/tests/playwright/tests/theme-settings.test.ts
@@ -1,6 +1,7 @@
 import { parallelTest as test } from '../parallelTest.ts';
 import { expect } from '@playwright/test';
 import WpAdminPage from '../pages/wp-admin-page.ts';
+import SettingsPage from '../pages/settings-page.ts';
 
 test.describe('Admin Menu', () => {
 	test('Hello Elementor menu exists in sidebar with correct name', async ({
@@ -37,5 +38,22 @@ test.describe('Admin Menu', () => {
 		await helloMenu.hover();
 
 		await expect(helloMenu.locator('.wp-submenu li')).toHaveCount(0);
+	});
+
+	test('shows Upgrade Now button in top bar when Elementor Pro is inactive', async ({
+		page,
+		apiRequests,
+	}, testInfo) => {
+		const settingsPage = new SettingsPage(page, testInfo, apiRequests);
+
+		await settingsPage.gotoSettingsPage();
+
+		const upgradeButton = page.getByRole('link', { name: 'Upgrade Now' });
+		await expect(upgradeButton).toBeVisible();
+		await expect(upgradeButton).toHaveAttribute(
+			'href',
+			'https://go.elementor.com/go-pro-hello-theme-upgrade-top-bar/',
+		);
+		await expect(upgradeButton).toHaveAttribute('target', '_blank');
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### TMZ-1069: Upgrade notice copy

Updates the Hello Theme admin welcome/upgrade notice shown when Elementor is active but Pro is not installed. The new copy explicitly mentions Elementor Pro and the Elementor Editor.

**Before:**
- Title: "Go Pro, Go Limitless"
- Text: "Unlock the theme builder, popup builder, 100+ widgets and more advanced tools to take your website to the next level."

**After:**
- Title: "Build more with Elementor Pro"
- Text: "Add the theme builder, popup builder, and 85+ advanced widgets to your Elementor Editor."

Button text ("Upgrade now") is unchanged.

### TMZ-1067: Top bar Upgrade to Pro button

Fixes the top bar upgrade CTA go link to match the ticket spec (`go-pro-hello-theme-upgrade-top-bar` instead of `hello-upgrade-epro`). Adds a Playwright test that verifies the crown + "Upgrade Now" button appears on the settings page when Elementor Pro is inactive.

## Jira

- https://elementor.atlassian.net/browse/TMZ-1069
- https://elementor.atlassian.net/browse/TMZ-1067
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00e64-4bce-7560-b79b-511da3dc839f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00e64-4bce-7560-b79b-511da3dc839f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Updates upgrade funnel messaging and tracking links to align with marketing copy (TMZ-1069, TMZ-1067). Top bar upgrade link now routes through dedicated tracking parameter.

## 2. What Changed (Where)

- **admin-top-bar.php**: Updated `UPGRADE_PRO_URL` constant from `hello-upgrade-epro/` to `go-pro-hello-theme-upgrade-top-bar/`
- **admin-config.php**: Rewrote welcome notice title/text from "Go Pro, Go Limitless" to "Build more with Elementor Pro" with revised features list
- **theme-settings.test.ts**: Added test verifying top bar upgrade button visibility and correct href routing

## 3. How It Works

Marketing copy change flows through admin welcome config. Top bar component uses new tracking URL constant for click attribution. Test validates button presence and href routing on settings page load.

## 4. Risks

None identified. Copy-only change with test coverage. Link parameter change is transparent to user experience.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
