### PR TITLE
Internal: Fix conversion banner placeholder shifting admin buttons [ED-25235]

### DIFF
--- a/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
+++ b/modules/admin-home/assets/js/hello-elementor-conversion-banner.js
@@ -1,13 +1,18 @@
+import apiFetch from '@wordpress/api-fetch';
 import { createRoot } from 'react-dom/client';
+import { useLayoutEffect } from 'react';
 import { ThemeProvider } from '@elementor/ui/styles';
 import { Welcome } from './components/paper/welcome';
 import { AdminProvider } from './providers/admin-provider';
-import Box from '@elementor/ui/Box';
 
-const App = () => {
+const App = ({ config, container }) => {
+	useLayoutEffect(() => {
+		container.style.visibility = 'visible';
+	}, [container]);
+
 	return (
 		<ThemeProvider colorScheme="light">
-			<AdminProvider>
+			<AdminProvider initialSettings={config}>
 				<Welcome
 					sx={{
 						mt: 2,
@@ -25,28 +30,86 @@ const App = () => {
 	);
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-	const container = document.getElementById('ehe-admin-cb');
+const insertBanner = (container, placement) => {
+	const { beforeWrap = false, selector, before = false } = placement;
 
-	if (container) {
-		const { beforeWrap = false } = window.ehe_cb;
-		const { selector, before = false } = window.ehe_cb.data;
-		const headerEnd = document.querySelector(selector);
+	if (beforeWrap) {
+		const wrapElement = document.querySelector('.wrap');
 
-		if (headerEnd) {
-			if (beforeWrap) {
-				const wrapElement = document.querySelector('.wrap');
-				if (wrapElement) {
-					wrapElement.insertAdjacentElement('beforebegin', container);
-				}
-			} else if (before) {
-				headerEnd.insertAdjacentElement('beforebegin', container);
-			} else {
-				headerEnd.insertAdjacentElement('afterend', container);
-			}
+		if (!wrapElement) {
+			return false;
 		}
 
-		const root = createRoot(container);
-		root.render(<App />);
+		wrapElement.insertAdjacentElement('beforebegin', container);
+		return true;
 	}
-});
+
+	if (before) {
+		const anchor = document.querySelector(selector);
+
+		if (!anchor) {
+			return false;
+		}
+
+		anchor.insertAdjacentElement('beforebegin', container);
+		return true;
+	}
+
+	const pageTitleAction = document.querySelector('.wrap .page-title-action');
+
+	if (pageTitleAction) {
+		pageTitleAction.insertAdjacentElement('afterend', container);
+		return true;
+	}
+
+	const headerEnd = document.querySelector(selector);
+
+	if (!headerEnd) {
+		return false;
+	}
+
+	headerEnd.insertAdjacentElement('afterend', container);
+	return true;
+};
+
+const init = async () => {
+	if ('undefined' === typeof window.ehe_cb) {
+		return;
+	}
+
+	let config;
+
+	try {
+		const response = await apiFetch({
+			path: '/elementor-hello-elementor/v1/admin-settings',
+		});
+		config = response.config;
+	} catch (e) {
+		return;
+	}
+
+	if (!config?.welcome?.title) {
+		return;
+	}
+
+	const { beforeWrap = false } = window.ehe_cb;
+	const { selector, before = false } = window.ehe_cb.data;
+
+	const container = document.createElement('div');
+	container.id = 'ehe-admin-cb';
+	container.className = 'ehe-admin-cb';
+	container.style.visibility = 'hidden';
+
+	if (!insertBanner(container, { beforeWrap, selector, before })) {
+		return;
+	}
+
+	const root = createRoot(container);
+	root.render(<App config={config} container={container} />);
+};
+
+if ('loading' === document.readyState) {
+	document.addEventListener('DOMContentLoaded', init);
+} else {
+	init();
+}

--- a/modules/admin-home/assets/js/providers/admin-provider.js
+++ b/modules/admin-home/assets/js/providers/admin-provider.js
@@ -3,11 +3,17 @@ import apiFetch from '@wordpress/api-fetch';
 
 export const AdminContext = createContext();
 
-export const AdminProvider = ({ children }) => {
-	const [isLoading, setIsLoading] = React.useState(true);
-	const [adminSettings, setAdminSettings] = React.useState({});
+export const AdminProvider = ({ children, initialSettings = null }) => {
+	const [isLoading, setIsLoading] = React.useState(!initialSettings);
+	const [adminSettings, setAdminSettings] = React.useState(
+		initialSettings || {},
+	);
 
 	useEffect(() => {
+		if (initialSettings) {
+			return;
+		}
+
 		apiFetch({ path: '/elementor-hello-elementor/v1/admin-settings' })
 			.then((settings) => {
 				setAdminSettings(settings.config);
@@ -15,7 +21,7 @@ export const AdminProvider = ({ children }) => {
 			.finally(() => {
 				setIsLoading(false);
 			});
-	}, []);
+	}, [initialSettings]);
 
 	return (
 		<AdminContext.Provider

--- a/modules/admin-home/components/conversion-banner.php
+++ b/modules/admin-home/components/conversion-banner.php
@@ -18,13 +18,6 @@ class Conversion_Banner {
 	const USER_META_KEY = '_hello_elementor_install_notice';
 	const AJAX_ACTION = 'ehe_dismiss_theme_notice';
 
-	private function render_conversion_banner() {
-		?>
-		<div id="ehe-admin-cb" style="width: calc(100% - 48px)">
-		</div>
-		<?php
-	}
-
 	private function get_allowed_admin_pages(): array {
 		return [
 			'dashboard' => [ 'selector' => '#wpbody #wpbody-content .wrap h1' ],
@@ -198,10 +191,6 @@ class Conversion_Banner {
 			if ( ! $conversion_banner_active ) {
 				return;
 			}
-
-			add_action( 'in_admin_header', function () {
-				$this->render_conversion_banner();
-			}, 11 );
 
 			add_action( 'admin_enqueue_scripts', function () use ( $conversion_banner_active ) {
 				$this->enqueue_scripts( $conversion_banner_active );

--- a/tests/playwright/tests/conversion-banner-layout.test.ts
+++ b/tests/playwright/tests/conversion-banner-layout.test.ts
@@ -3,11 +3,32 @@ import { expect } from '@playwright/test';
 import WpAdminPage from '../pages/wp-admin-page.ts';
 import { timeouts } from '../config/timeouts.ts';
 
+const emptyWelcomeAdminSettings = {
+	config: {
+		welcome: [],
+		config: {
+			nonceInstall: 'test-nonce',
+			slug: 'elementor',
+		},
+	},
+};
+
 test.describe('Conversion banner flows [ED-25235]', () => {
-	test('Pages list does not mount banner when Elementor suppresses welcome config', async ({
+	test('Pages list does not mount banner when welcome config is empty', async ({
 		page,
 		apiRequests,
 	}, testInfo) => {
+		await page.route(
+			'**/elementor-hello-elementor/v1/admin-settings**',
+			async (route) => {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify(emptyWelcomeAdminSettings),
+				});
+			},
+		);
+
 		const wpAdmin = new WpAdminPage(page, testInfo, apiRequests);
 
 		await wpAdmin.login();

--- a/tests/playwright/tests/conversion-banner-layout.test.ts
+++ b/tests/playwright/tests/conversion-banner-layout.test.ts
@@ -1,0 +1,128 @@
+import { parallelTest as test } from '../parallelTest.ts';
+import { expect } from '@playwright/test';
+import WpAdminPage from '../pages/wp-admin-page.ts';
+import { timeouts } from '../config/timeouts.ts';
+
+test.describe('Conversion banner flows [ED-25235]', () => {
+	test('Pages list does not mount banner when Elementor suppresses welcome config', async ({
+		page,
+		apiRequests,
+	}, testInfo) => {
+		const wpAdmin = new WpAdminPage(page, testInfo, apiRequests);
+
+		await wpAdmin.login();
+
+		await page.goto('/wp-admin/edit.php?post_type=page', {
+			waitUntil: 'networkidle',
+			timeout: timeouts.longAction,
+		});
+
+		await page.waitForSelector('.wrap h1.wp-heading-inline', {
+			timeout: timeouts.longAction,
+		});
+
+		await page.waitForTimeout(timeouts.longAction / 5);
+
+		await expect(page.locator('#ehe-admin-cb')).toHaveCount(0);
+
+		const headingBox = await page
+			.locator('.wrap h1.wp-heading-inline')
+			.boundingBox();
+		const actionBox = await page
+			.locator('.wrap .page-title-action')
+			.first()
+			.boundingBox();
+
+		expect(headingBox).not.toBeNull();
+		expect(actionBox).not.toBeNull();
+
+		if (headingBox && actionBox) {
+			expect(actionBox.y).toBeLessThan(headingBox.y + headingBox.height + 8);
+		}
+	});
+
+	test('Hello settings page still loads without conversion banner regressions', async ({
+		page,
+		apiRequests,
+	}, testInfo) => {
+		const wpAdmin = new WpAdminPage(page, testInfo, apiRequests);
+
+		await wpAdmin.login();
+
+		await page.goto('/wp-admin/admin.php?page=hello-elementor-settings', {
+			waitUntil: 'networkidle',
+			timeout: timeouts.longAction,
+		});
+
+		await expect(page.locator('#ehe-admin-settings')).toBeVisible({
+			timeout: timeouts.longAction,
+		});
+
+		const bannerCount = await page.locator('#ehe-admin-cb').count();
+
+		if (bannerCount > 0) {
+			const action = page.locator('.wrap .page-title-action').first();
+			const banner = page.locator('#ehe-admin-cb');
+
+			if ((await action.count()) > 0) {
+				const isAfterAction = await page.evaluate(() => {
+					const actionNode = document.querySelector('.wrap .page-title-action');
+					const bannerNode = document.getElementById('ehe-admin-cb');
+
+					return Boolean(
+						actionNode &&
+							bannerNode &&
+							actionNode.nextElementSibling === bannerNode,
+					);
+				});
+
+				expect(isAfterAction).toBe(true);
+			}
+		}
+	});
+
+	test('Plugins page keeps native title row when banner is absent', async ({
+		page,
+		apiRequests,
+	}, testInfo) => {
+		const wpAdmin = new WpAdminPage(page, testInfo, apiRequests);
+
+		await wpAdmin.login();
+
+		await page.goto('/wp-admin/plugins.php', {
+			waitUntil: 'networkidle',
+			timeout: timeouts.longAction,
+		});
+
+		await page.waitForSelector('.wrap h1', {
+			timeout: timeouts.longAction,
+		});
+
+		await page.waitForTimeout(timeouts.longAction / 5);
+
+		const banner = page.locator('#ehe-admin-cb');
+		const bannerCount = await banner.count();
+
+		if (bannerCount > 0) {
+			const heading = page.locator('.wrap h1').first();
+			const action = page.locator('.wrap .page-title-action').first();
+
+			if ((await action.count()) > 0) {
+				const isAfterAction = await page.evaluate(() => {
+					const actionNode = document.querySelector('.wrap .page-title-action');
+					const bannerNode = document.getElementById('ehe-admin-cb');
+
+					return Boolean(
+						actionNode &&
+							bannerNode &&
+							actionNode.nextElementSibling === bannerNode,
+					);
+				});
+
+				expect(isAfterAction).toBe(true);
+			}
+
+			await expect(heading).toBeVisible();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Remove the empty `#ehe-admin-cb` placeholder rendered in PHP via `in_admin_header`, which sat between the page title and `.page-title-action` and shifted buttons in Editor One admin layouts.
- Create and mount the banner in JavaScript only after REST confirms welcome content exists (`config.welcome.title`), so suppressed banners leave no DOM node.
- Place the banner after `.page-title-action` on standard list-table screens (fallback: after the configured heading selector); preserve existing `before` and `beforeWrap` placement for special screens.
- Pass pre-fetched admin settings into `AdminProvider` to avoid a duplicate REST request; add Playwright regression tests for the main flows.

## Jira

[ED-25235](https://elementor.atlassian.net/browse/ED-25235)

## Test plan

- [x] Playwright: Pages list — no `#ehe-admin-cb` when Elementor suppresses welcome config; title row stays aligned
- [x] Playwright: Hello settings page loads; banner (if present) sits after `.page-title-action`
- [x] Playwright: Plugins page title row intact when banner is absent
- [ ] Manual: Free Elementor (no Pro) on Hello settings — Go Pro banner appears below title row, not between `h1` and buttons
- [ ] Manual: Dismiss banner via AJAX — does not reappear on reload
- [ ] Manual: `before: true` screens (templates library, system info) — banner still appears before anchor
- [ ] Manual: Upload-plugin uploader (`beforeWrap`) — banner appears before `.wrap`

## Labels

`patch`

Made with [Cursor](https://cursor.com)

[ED-25235]: https://elementor.atlassian.net/browse/ED-25235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Banner's fixed width and PHP-injected placeholder DOM were causing admin buttons to shift. Moved rendering to JavaScript with dynamic insertion logic to avoid layout thrashing and ensure proper positioning.

## 2. What Changed (Where)

- **conversion-banner.php**: Removed `render_conversion_banner()` method and `in_admin_header` hook; banner now created client-side.
- **hello-elementor-conversion-banner.js**: Refactored to fetch config via API, dynamically create container with visibility hidden, then inject at computed insertion point.
- **admin-provider.js**: Added `initialSettings` prop to skip redundant API call when config already fetched.
- **conversion-banner-layout.test.ts**: Added E2E tests validating banner placement doesn't displace page-title-action buttons.

## 3. How It Works

Init function fires on DOMContentLoaded, fetches config via REST API, creates hidden container, calls `insertBanner()` to locate insertion point (beforeWrap > before selector > after page-title-action > after selector), renders React app, then reveals container via `useLayoutEffect`. This prevents reflow of admin buttons since container is invisible during DOM insertion.

## 4. Risks

Minor: API fetch failure silently aborts (no retry). Banner won't render if `initialSettings.welcome.title` missing, but test coverage validates this. Insertion logic depends on specific DOM selectors being present—validate across WordPress admin pages where selectors differ (dashboard special-cases to `#wpbody-content .wrap h1`).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
