### PR TITLE
Fix: Improve keyboard navigation for Accessibility Ready compliance

### DIFF
--- a/dev/scss/reset.scss
+++ b/dev/scss/reset.scss
@@ -3,3 +3,4 @@
 @forward "reset/forms";
 @forward "reset/table";
 @forward "reset/list";
+@forward "reset/focus";

--- a/dev/scss/reset/_focus.scss
+++ b/dev/scss/reset/_focus.scss
@@ -1,0 +1,23 @@
+/**
+ * Global :focus-visible — two-tone outline visible on any background.
+ * Black inner ring + white outer glow gives >=3:1 contrast on both
+ * light and dark surfaces without relying on browser defaults.
+ */
+
+a,
+button,
+input,
+select,
+textarea,
+[tabindex]:not([tabindex="-1"]) {
+	&:focus-visible {
+		outline: 2px solid #000;
+		outline-offset: 2px;
+		box-shadow: 0 0 0 4px #fff;
+	}
+
+	&:focus:not(:focus-visible) {
+		outline: none;
+		box-shadow: none;
+	}
+}

--- a/dev/scss/reset/_forms.scss
+++ b/dev/scss/reset/_forms.scss
@@ -101,10 +101,6 @@ button,
 	border-radius: variables.$border-radius;
 	transition: all .3s;
 
-	&:focus:not(:focus-visible) {
-		outline: none;
-	}
-
 	&:hover,
 	&:focus {
 		color: #fff;

--- a/dev/scss/reset/_reset.scss
+++ b/dev/scss/reset/_reset.scss
@@ -35,6 +35,7 @@ body {
 	background-color: #fff;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	overflow-x: clip;
 }
 
 /**

--- a/dev/scss/theme/_general.scss
+++ b/dev/scss/theme/_general.scss
@@ -38,9 +38,10 @@
 	margin-inline: calc(50% - 50vw);
 	max-width: 100vw;
 	width: 100vw;
+	overflow-x: hidden;
 
 	img  {
-		width: 100vw;
+		width: 100%;
 	}
 }
 

--- a/dev/scss/theme/_navigation.scss
+++ b/dev/scss/theme/_navigation.scss
@@ -95,6 +95,15 @@
 				padding: 8px 15px;
 			}
 
+			ul a {
+				color: variables.$gray-dark;
+
+				&:hover,
+				&:focus {
+					color: variables.$gray-darker;
+				}
+			}
+
 			&.menu-item-has-children {
 				padding-inline-end: 15px;
 
@@ -116,14 +125,15 @@
 				}
 			}
 
-			ul {
-				background: #fff;
-				display: none;
-				min-width: 150px;
-				position: absolute;
-				z-index: 2;
-				left: 0;
-				top: 100%;
+		ul {
+			background: #fff;
+			display: none;
+			min-width: 150px;
+			max-width: calc(100vw - 2rem);
+			position: absolute;
+			z-index: 2;
+			left: 0;
+			top: 100%;
 
 				li {
 					border-block-end: variables.$gray-lighter 1px solid;
@@ -150,14 +160,20 @@
 				}
 			}
 
-			&:hover {
+		&:last-child > ul,
+		&:nth-last-child(2) > ul {
+			left: auto;
+			inset-inline-end: 0;
+		}
 
-				& > ul {
-					display: block;
-				}
+		&:hover {
+
+			& > ul {
+				display: block;
 			}
 		}
 	}
+}
 }
 
 footer {

--- a/dev/scss/theme/_navigation.scss
+++ b/dev/scss/theme/_navigation.scss
@@ -132,8 +132,8 @@
 			max-width: calc(100vw - 2rem);
 			position: absolute;
 			z-index: 2;
-			left: 0;
-			top: 100%;
+			inset-inline-start: 0;
+			inset-block-start: 100%;
 
 				li {
 					border-block-end: variables.$gray-lighter 1px solid;
@@ -155,14 +155,14 @@
 				}
 
 				ul {
-					left: 100%;
-					top: 0;
+					inset-inline-start: 100%;
+					inset-block-start: 0;
 				}
 			}
 
 		&:last-child > ul,
 		&:nth-last-child(2) > ul {
-			left: auto;
+			inset-inline-start: auto;
 			inset-inline-end: 0;
 		}
 

--- a/includes/settings/settings-header.php
+++ b/includes/settings/settings-header.php
@@ -686,7 +686,8 @@ class Settings_Header extends Tab_Base {
 						'hello_header_menu_display' => 'yes',
 					],
 					'selectors' => [
-						'.site-header .site-navigation ul.menu li a' => 'color: {{VALUE}};',
+						'.site-header .site-navigation ul.menu > li > a' => 'color: {{VALUE}};',
+						'.site-header .site-navigation ul.menu > li.menu-item-has-children::after' => 'color: {{VALUE}};',
 					],
 				]
 			);

--- a/template-parts/dynamic-header.php
+++ b/template-parts/dynamic-header.php
@@ -59,7 +59,7 @@ $header_mobile_nav_menu = wp_nav_menu( $menu_args ); // The same menu but separa
 		<?php endif; ?>
 		<?php if ( $header_mobile_nav_menu ) : ?>
 			<div class="site-navigation-toggle-holder <?php echo esc_attr( hello_show_or_hide( 'hello_header_menu_display' ) ); ?>">
-				<button type="button" class="site-navigation-toggle" aria-label="<?php echo esc_attr( 'Menu', 'hello-elementor' ); ?>">
+				<button type="button" class="site-navigation-toggle" aria-expanded="false" aria-label="<?php echo esc_attr__( 'Menu', 'hello-elementor' ); ?>">
 					<span class="site-navigation-toggle-icon" aria-hidden="true"></span>
 				</button>
 			</div>


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Improving keyboard accessibility for WCAG 2.1 AA compliance. Adds visible focus indicators and fixes keyboard navigation for dropdown menus and mobile nav toggles.

## 2. What Changed (Where)

- **Settings Header**: Refined menu color selectors to target direct children only (removes `.site-navigation-dropdown` overshoot)
- **Dynamic Header**: Added `aria-expanded` and `esc_attr__()` to mobile nav toggle button for keyboard state tracking
- **Focus Styles**: New `_focus.scss` with global `:focus-visible` outline (2px black + 4px white glow) supporting light/dark backgrounds
- **Navigation & Layout**: Migrated to logical properties (`inset-*`), added dropdown positioning fixes, removed focus-only rules from forms, added `overflow-x: clip/hidden` for full-width alignments

## 3. How It Works

Mobile menu button now announces expanded state via ARIA. Global focus ring applies to all interactive elements with 3:1 contrast guarantee. Dropdown menus repositioned to logical properties (RTL-compatible), with special handling for bottom-aligned items. Full-width Gutenberg blocks constrained via viewport overflow controls.

## 4. Risks

Focus ring color (#000 + #fff) assumes sufficient page contrast; test on colorful backgrounds. Dropdown positioning logic (`inset-inline-start: auto; inset-inline-end: 0` on last/second-last) may conflict with RTL transforms—verify in RTL context. `aria-expanded` requires JS to toggle; verify implementation elsewhere.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
