### PR TITLE
Internal: Suppress Hello Pro banner when Elementor Core is active [TMZ-1072]

### DIFF
--- a/modules/admin-home/components/conversion-banner.php
+++ b/modules/admin-home/components/conversion-banner.php
@@ -146,7 +146,7 @@ class Conversion_Banner {
 			return [];
 		}
 
-		if ( Utils::has_pro() && Utils::is_elementor_active() ) {
+		if ( Utils::has_pro() || Utils::is_elementor_active() ) {
 			return [];
 		}
 

--- a/modules/admin-home/rest/admin-config.php
+++ b/modules/admin-home/rest/admin-config.php
@@ -39,7 +39,6 @@ class Admin_Config extends Rest_Base {
 	public function get_welcome_box_config( array $config ): array {
 		$is_elementor_installed = Utils::is_elementor_installed();
 		$is_elementor_active    = Utils::is_elementor_active();
-		$has_pro                = Utils::has_pro();
 
 		if ( ! $is_elementor_active ) {
 			$link = $is_elementor_installed ? Utils::get_elementor_activation_link() : 'install';
@@ -68,24 +67,6 @@ class Admin_Config extends Rest_Base {
 				'image'   => [
 					'src' => HELLO_THEME_IMAGES_URL . 'install-elementor.png',
 					'alt' => $cta_text,
-				],
-			];
-
-			return $config;
-		}
-
-		if ( $is_elementor_active && ! $has_pro ) {
-			$config['welcome'] = [
-				'title'   => __( 'Build more with Elementor Pro', 'hello-elementor' ),
-				'text'    => __( 'Add the theme builder, popup builder, and 85+ advanced widgets to your Elementor Editor.', 'hello-elementor' ),
-				'buttons' => [
-					[
-						'linkText' => __( 'Upgrade now', 'hello-elementor' ),
-						'variant'  => 'contained',
-						'link'     => 'https://go.elementor.com/hello-upgrade-epro/',
-						'color'    => 'primary',
-						'target'   => '_blank',
-					],
 				],
 			];
 

--- a/tests/playwright/tests/conversion-banner-layout.test.ts
+++ b/tests/playwright/tests/conversion-banner-layout.test.ts
@@ -3,32 +3,11 @@ import { expect } from '@playwright/test';
 import WpAdminPage from '../pages/wp-admin-page.ts';
 import { timeouts } from '../config/timeouts.ts';
 
-const emptyWelcomeAdminSettings = {
-	config: {
-		welcome: [],
-		config: {
-			nonceInstall: 'test-nonce',
-			slug: 'elementor',
-		},
-	},
-};
-
-test.describe('Conversion banner flows [ED-25235]', () => {
-	test('Pages list does not mount banner when welcome config is empty', async ({
+test.describe('Conversion banner flows [ED-24302]', () => {
+	test('Pages list does not mount Hello Pro banner when Elementor Core is active', async ({
 		page,
 		apiRequests,
 	}, testInfo) => {
-		await page.route(
-			'**/elementor-hello-elementor/v1/admin-settings**',
-			async (route) => {
-				await route.fulfill({
-					status: 200,
-					contentType: 'application/json',
-					body: JSON.stringify(emptyWelcomeAdminSettings),
-				});
-			},
-		);
-
 		const wpAdmin = new WpAdminPage(page, testInfo, apiRequests);
 
 		await wpAdmin.login();

--- a/tests/playwright/tests/conversion-banner-layout.test.ts
+++ b/tests/playwright/tests/conversion-banner-layout.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import WpAdminPage from '../pages/wp-admin-page.ts';
 import { timeouts } from '../config/timeouts.ts';
 
-test.describe('Conversion banner flows [ED-24302]', () => {
+test.describe('Conversion banner flows [TMZ-1072]', () => {
 	test('Pages list does not mount Hello Pro banner when Elementor Core is active', async ({
 		page,
 		apiRequests,


### PR DESCRIPTION
## Summary
- Stop enqueueing the Hello theme conversion banner when Elementor Core is active (or Pro is installed), since Core already shows its own upgrade notice
- Remove the duplicate "Build more with Elementor Pro" welcome config from the Hello admin REST API when Core is present
- Update Playwright coverage to assert the Hello banner does not mount on admin list pages with Core active

## Jira
[TMZ-1072](https://elementor.atlassian.net/browse/TMZ-1072) — Pro banner is duplicated when Core and Hello exists

## Test plan
- [ ] With Hello Theme + Elementor Core (free): confirm only Core's `#e-conversion-banner` appears on WP admin pages (e.g. Pages list, Plugins), not Hello's `#ehe-admin-cb`
- [ ] With Hello Theme only (Elementor not active): confirm Hello still shows the install/activate Elementor welcome banner
- [ ] With Elementor Pro installed: confirm neither Pro upgrade banner appears from Hello
- [ ] Run Playwright: `conversion-banner-layout.test.ts`

[TMZ-1072]: https://elementor.atlassian.net/browse/TMZ-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Suppress the Hello Pro upsell banner when Elementor Core is active—currently the banner only hides when Pro is installed AND Core is active, but should hide for either condition (ED-24302).

## 2. What Changed (Where)
- `conversion-banner.php`: Changed condition from AND to OR—now suppresses banner if Pro exists OR Core is active
- `admin-config.php`: Removed hardcoded Pro upsell welcome box and `$has_pro` variable entirely
- `conversion-banner-layout.test.ts`: Updated test to reflect new behavior; simplified mock setup

## 3. How It Works
Entry point is `is_conversion_banner_active()`. Previously required both `has_pro() && is_elementor_active()` to suppress; now requires only one condition met. Upsell content in `admin-config.php` is now unconditionally removed for active Elementor installs, delegating suppression logic to the banner component.

## 4. Risks
None—logic is more permissive (shows fewer banners), and `is_elementor_active()` is an existing utility. Test changes are straightforward and cover the actual behavior now.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
