### PR TITLE
Internal: Grant nested build permissions in Deploy workflow [TMZ-1053]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,11 @@ jobs:
     needs: validate
     uses: ./.github/workflows/build.yml
     secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
+      pull-requests: write
 
   deploy:
     needs: [validate, build]


### PR DESCRIPTION
## Summary
- Grant `deployments: write` and `pull-requests: write` on the Deploy workflow's `build` job so it can call `build.yml`
- GitHub rejects the reusable workflow at parse time when nested jobs request those scopes, even if they are skipped on `workflow_dispatch`

## Test plan
- [ ] Confirm `deploy.yml` parses (no "Invalid workflow file" on the Deploy workflow)
- [ ] Confirm Deploy `workflow_dispatch` can run past the build reusable-workflow call


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Nested reusable workflows need explicit permission grants to execute restricted GitHub Actions (TMZ-1053). Without these, the `build.yml` job lacks authorization for deployments and PR operations.

## 2. What Changed (Where)

`.github/workflows/deploy.yml`: Added `permissions` block to `build` job granting `actions: read`, `contents: read`, `deployments: write`, `pull-requests: write`.

## 3. How It Works

Parent workflow (`deploy.yml`) delegates to reusable workflow (`build.yml`) via `uses`. Explicit permissions inherited via `secrets: inherit` now explicitly grant required capabilities for nested workflow execution.

## 4. Risks

None—minimal scope, scoped to build job only, follows GitHub best practices for nested workflows.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
