### PR TITLE
Internal: Update build ignore [TMZ-1074]

### DIFF
--- a/.buildignore
+++ b/.buildignore
@@ -13,6 +13,9 @@ package.json
 phpcs.xml
 phpunit.xml
 README.md
+AGENTS.md
+CLAUDE.md
+DEVELOPERS.md
 webpack.config.js
 .DS_Store
 .git/


### PR DESCRIPTION
## Summary
- Exclude agent/developer docs (`AGENTS.md`, `CLAUDE.md`, `DEVELOPERS.md`) from the packaged theme zip via `.buildignore`

## Jira
[TMZ-1074](https://elementor.atlassian.net/browse/TMZ-1074) — Internal: Update build ignore

## Test plan
- [ ] Confirm `AGENTS.md`, `CLAUDE.md`, and `DEVELOPERS.md` are listed in `.buildignore`
- [ ] Run `npm run package:zip` (or the zip script that uses `rsync --exclude-from=.buildignore`) and confirm those three files are not inside the zip
- [ ] Confirm `README.md` and other existing ignore entries are still excluded


Made with [Cursor](https://cursor.com)

[TMZ-1074]: https://elementor.atlassian.net/browse/TMZ-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adding documentation files (AGENTS.md, CLAUDE.md, DEVELOPERS.md) to buildignore to exclude them from production builds—housekeeping for a cleaner artifact footprint.

## 2. What Changed (Where)

- `.buildignore`: Added 3 markdown documentation files to exclusion list (lines 16–18)

## 3. How It Works

Build process reads `.buildignore` to filter files before packaging; these docs now excluded automatically.

## 4. Risks

None—additive change to ignore patterns, no impact on existing builds or runtime behavior.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
