### PR TITLE
Internal: Run WordPress Theme Check on pull requests [ED-25399]

### DIFF
--- a/.github/scripts/run-theme-check.sh
+++ b/.github/scripts/run-theme-check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+REPORT_FILE="${THEME_CHECK_REPORT:-theme-check-report.txt}"
+COMMENT_FILE="${THEME_CHECK_COMMENT:-theme-check-comment.md}"
+MAX_COMMENT_BYTES="${THEME_CHECK_MAX_COMMENT_BYTES:-58000}"
+
+ZIP=$(find . -maxdepth 1 -name 'hello-elementor*.zip' -type f | head -1)
+cp "$ZIP" tests/wp-env/config/hello-elementor-dist.zip
+
+set +e
+npx wp-env run cli bash hello-elementor-config/theme-check.sh > "$REPORT_FILE" 2>&1
+EXIT_CODE=$?
+set -e
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "${EXIT_CODE}" -eq 0 ]]; then
+	STATUS_LABEL="passed"
+else
+	STATUS_LABEL="failed"
+fi
+
+{
+	echo "<!-- hello-elementor-theme-check -->"
+	echo "## WordPress Theme Check"
+	echo
+	echo "Status: **${STATUS_LABEL}** (exit code ${EXIT_CODE})"
+	echo
+	echo "Ran [Theme Check](https://github.com/WordPress/theme-check) against the packaged \`hello-elementor\` zip."
+	echo
+	echo '```text'
+	if [[ "$(wc -c < "$REPORT_FILE")" -gt "${MAX_COMMENT_BYTES}" ]]; then
+		head -c "${MAX_COMMENT_BYTES}" "$REPORT_FILE"
+		echo
+		echo "... output truncated to fit the GitHub comment size limit. Full report is attached as the theme-check-report artifact."
+	else
+		cat "$REPORT_FILE"
+	fi
+	echo '```'
+} > "$COMMENT_FILE"
+
+exit "${EXIT_CODE}"

--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -1,0 +1,87 @@
+name: Theme Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  theme-check:
+    name: WordPress Theme Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: npm
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          composer install --no-dev --no-scripts --optimize-autoloader
+
+      - name: Package theme zip
+        run: npm run zip
+
+      - name: Start wp-env
+        run: npm run wp-env:start
+
+      - name: Run Theme Check
+        id: theme-check
+        continue-on-error: true
+        run: bash .github/scripts/run-theme-check.sh
+
+      - name: Upload Theme Check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theme-check-report
+          path: |
+            theme-check-report.txt
+            theme-check-comment.md
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Find existing Theme Check comment
+        if: always()
+        uses: peter-evans/find-comment@v4
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- hello-elementor-theme-check -->'
+
+      - name: Comment Theme Check output on PR
+        if: always()
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: theme-check-comment.md
+          edit-mode: replace
+
+      - name: Stop wp-env
+        if: always()
+        run: npm run wp-env:stop
+
+      - name: Fail on Theme Check errors
+        if: steps.theme-check.outcome == 'failure'
+        run: exit 1

--- a/tests/wp-env/config/theme-check.sh
+++ b/tests/wp-env/config/theme-check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+wp plugin install theme-check --activate --force
+wp theme install /var/www/html/hello-elementor-config/hello-elementor-dist.zip --force --activate
+wp theme-check run hello-elementor --format=table


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a pull request check that runs the official [WordPress Theme Check](https://github.com/WordPress/theme-check) plugin — the same automated checker wordpress.org uses on theme uploads.

On each PR the workflow:

1. Builds the distributable `hello-elementor` zip (not the raw git tree)
2. Starts `wp-env`, installs Theme Check, and installs that zip as the `hello-elementor` theme
3. Runs `wp theme-check run hello-elementor`
4. Posts the full report as a sticky PR comment (`<!-- hello-elementor-theme-check -->`), updated on each push
5. Uploads `theme-check-report.txt` as an artifact if the report exceeds GitHub’s comment size limit
6. Fails the check when Theme Check exits non-zero

## Jira

[ED-25399](https://elementor.atlassian.net/browse/ED-25399)

## Test plan

- [x] Confirm the Theme Check workflow runs on this PR
- [x] Confirm the sticky PR comment contains the full Theme Check table
- [x] Confirm the `theme-check-report` artifact is uploaded
- [x] Confirm a later push updates the same comment instead of adding a new one

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03988-c3de-71ba-891e-efc66eedd5bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03988-c3de-71ba-891e-efc66eedd5bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ED-25399]: https://elementor.atlassian.net/browse/ED-25399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ